### PR TITLE
BlockEncoder instruction size optimization fix

### DIFF
--- a/src/rust/iced-x86/src/block_enc.rs
+++ b/src/rust/iced-x86/src/block_enc.rs
@@ -314,7 +314,7 @@ impl BlockEncoder {
 			let mut updated = false;
 			for info in &mut self.blocks {
 				let mut ip = info.0.borrow().rip;
-                let mut gained = 0;
+				let mut gained = 0;
 				for instr in &mut info.1 {
 					let mut instr = instr.borrow_mut();
 					instr.set_ip(ip);
@@ -325,7 +325,7 @@ impl BlockEncoder {
 							return Err(IcedError::new("Internal error"));
 						}
 						if instr_size < old_size {
-                            gained += (instr_size - old_size) as u64;
+							gained += (instr_size - old_size) as u64;
 							updated = true;
 						}
 					} else if instr.size() != old_size {

--- a/src/rust/iced-x86/src/block_enc.rs
+++ b/src/rust/iced-x86/src/block_enc.rs
@@ -325,7 +325,7 @@ impl BlockEncoder {
 							return Err(IcedError::new("Internal error"));
 						}
 						if instr_size < old_size {
-							gained += (instr_size - old_size) as u64;
+							gained += (old_size - instr_size) as u64;
 							updated = true;
 						}
 					} else if instr.size() != old_size {

--- a/src/rust/iced-x86/src/block_enc.rs
+++ b/src/rust/iced-x86/src/block_enc.rs
@@ -314,16 +314,18 @@ impl BlockEncoder {
 			let mut updated = false;
 			for info in &mut self.blocks {
 				let mut ip = info.0.borrow().rip;
+                let mut gained = 0;
 				for instr in &mut info.1 {
 					let mut instr = instr.borrow_mut();
 					instr.set_ip(ip);
 					let old_size = instr.size();
-					if instr.optimize() {
+					if instr.optimize(gained) {
 						let instr_size = instr.size();
 						if instr_size > old_size {
 							return Err(IcedError::new("Internal error"));
 						}
 						if instr_size < old_size {
+                            gained += (instr_size - old_size) as u64;
 							updated = true;
 						}
 					} else if instr.size() != old_size {

--- a/src/rust/iced-x86/src/block_enc/instr/call_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/call_instr.rs
@@ -53,7 +53,7 @@ impl CallInstr {
 		}
 	}
 
-	fn try_optimize(&mut self) -> bool {
+	fn try_optimize(&mut self, gained: u64) -> bool {
 		if self.done {
 			return false;
 		}
@@ -64,6 +64,7 @@ impl CallInstr {
 			let target_address = self.target_instr.address(self);
 			let next_rip = self.ip.wrapping_add(self.orig_instruction_size as u64);
 			let diff = target_address.wrapping_sub(next_rip) as i64;
+            let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 			use_short = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 
@@ -107,11 +108,11 @@ impl Instr for CallInstr {
 
 	fn initialize(&mut self, block_encoder: &BlockEncoder) {
 		self.target_instr = block_encoder.get_target(self, self.instruction.near_branch_target());
-		let _ = self.try_optimize();
+		let _ = self.try_optimize(0);
 	}
 
-	fn optimize(&mut self) -> bool {
-		self.try_optimize()
+	fn optimize(&mut self, gained: u64) -> bool {
+		self.try_optimize(gained)
 	}
 
 	fn encode(&mut self, block: &mut Block) -> Result<(ConstantOffsets, bool), IcedError> {

--- a/src/rust/iced-x86/src/block_enc/instr/call_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/call_instr.rs
@@ -64,7 +64,7 @@ impl CallInstr {
 			let target_address = self.target_instr.address(self);
 			let next_rip = self.ip.wrapping_add(self.orig_instruction_size as u64);
 			let diff = target_address.wrapping_sub(next_rip) as i64;
-            let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+			let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 			use_short = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 

--- a/src/rust/iced-x86/src/block_enc/instr/ip_relmem_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/ip_relmem_instr.rs
@@ -65,7 +65,7 @@ impl IpRelMemOpInstr {
 		if !use_rip {
 			let next_rip = self.ip.wrapping_add(self.rip_instruction_size as u64);
 			let diff = target_address.wrapping_sub(next_rip) as i64;
-            let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+			let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 			use_rip = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 

--- a/src/rust/iced-x86/src/block_enc/instr/ip_relmem_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/ip_relmem_instr.rs
@@ -54,7 +54,7 @@ impl IpRelMemOpInstr {
 		}
 	}
 
-	fn try_optimize(&mut self) -> bool {
+	fn try_optimize(&mut self, gained: u64) -> bool {
 		if self.instr_kind == InstrKind::Unchanged || self.instr_kind == InstrKind::Rip || self.instr_kind == InstrKind::Eip {
 			return false;
 		}
@@ -65,6 +65,7 @@ impl IpRelMemOpInstr {
 		if !use_rip {
 			let next_rip = self.ip.wrapping_add(self.rip_instruction_size as u64);
 			let diff = target_address.wrapping_sub(next_rip) as i64;
+            let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 			use_rip = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 
@@ -109,11 +110,11 @@ impl Instr for IpRelMemOpInstr {
 
 	fn initialize(&mut self, block_encoder: &BlockEncoder) {
 		self.target_instr = block_encoder.get_target(self, self.instruction.ip_rel_memory_address());
-		let _ = self.try_optimize();
+		let _ = self.try_optimize(0);
 	}
 
-	fn optimize(&mut self) -> bool {
-		self.try_optimize()
+	fn optimize(&mut self, gained: u64) -> bool {
+		self.try_optimize(gained)
 	}
 
 	fn encode(&mut self, block: &mut Block) -> Result<(ConstantOffsets, bool), IcedError> {

--- a/src/rust/iced-x86/src/block_enc/instr/jcc_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/jcc_instr.rs
@@ -91,7 +91,7 @@ impl JccInstr {
 		let mut target_address = self.target_instr.address(self);
 		let mut next_rip = self.ip.wrapping_add(self.short_instruction_size as u64);
 		let mut diff = target_address.wrapping_sub(next_rip) as i64;
-        diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+		diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 		if i8::MIN as i64 <= diff && diff <= i8::MAX as i64 {
 			if let Some(ref pointer_data) = self.pointer_data {
 				pointer_data.borrow_mut().is_valid = false;
@@ -107,7 +107,7 @@ impl JccInstr {
 			target_address = self.target_instr.address(self);
 			next_rip = self.ip.wrapping_add(self.near_instruction_size as u64);
 			diff = target_address.wrapping_sub(next_rip) as i64;
-            diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+			diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 			use_near = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 		if use_near {

--- a/src/rust/iced-x86/src/block_enc/instr/jcc_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/jcc_instr.rs
@@ -83,7 +83,7 @@ impl JccInstr {
 		}
 	}
 
-	fn try_optimize(&mut self) -> bool {
+	fn try_optimize(&mut self, gained: u64) -> bool {
 		if self.instr_kind == InstrKind::Unchanged || self.instr_kind == InstrKind::Short {
 			return false;
 		}
@@ -91,6 +91,7 @@ impl JccInstr {
 		let mut target_address = self.target_instr.address(self);
 		let mut next_rip = self.ip.wrapping_add(self.short_instruction_size as u64);
 		let mut diff = target_address.wrapping_sub(next_rip) as i64;
+        diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 		if i8::MIN as i64 <= diff && diff <= i8::MAX as i64 {
 			if let Some(ref pointer_data) = self.pointer_data {
 				pointer_data.borrow_mut().is_valid = false;
@@ -106,6 +107,7 @@ impl JccInstr {
 			target_address = self.target_instr.address(self);
 			next_rip = self.ip.wrapping_add(self.near_instruction_size as u64);
 			diff = target_address.wrapping_sub(next_rip) as i64;
+            diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 			use_near = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 		if use_near {
@@ -177,11 +179,11 @@ impl Instr for JccInstr {
 
 	fn initialize(&mut self, block_encoder: &BlockEncoder) {
 		self.target_instr = block_encoder.get_target(self, self.instruction.near_branch_target());
-		let _ = self.try_optimize();
+		let _ = self.try_optimize(0);
 	}
 
-	fn optimize(&mut self) -> bool {
-		self.try_optimize()
+	fn optimize(&mut self, gained: u64) -> bool {
+		self.try_optimize(gained)
 	}
 
 	fn encode(&mut self, block: &mut Block) -> Result<(ConstantOffsets, bool), IcedError> {

--- a/src/rust/iced-x86/src/block_enc/instr/jmp_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/jmp_instr.rs
@@ -85,7 +85,7 @@ impl JmpInstr {
 		let mut target_address = self.target_instr.address(self);
 		let mut next_rip = self.ip.wrapping_add(self.short_instruction_size as u64);
 		let mut diff = target_address.wrapping_sub(next_rip) as i64;
-        diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+		diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 		if i8::MIN as i64 <= diff && diff <= i8::MAX as i64 {
 			if let Some(ref pointer_data) = self.pointer_data {
 				pointer_data.borrow_mut().is_valid = false;
@@ -101,7 +101,7 @@ impl JmpInstr {
 			target_address = self.target_instr.address(self);
 			next_rip = self.ip.wrapping_add(self.near_instruction_size as u64);
 			diff = target_address.wrapping_sub(next_rip) as i64;
-            diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+			diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 			use_near = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 		if use_near {

--- a/src/rust/iced-x86/src/block_enc/instr/jmp_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/jmp_instr.rs
@@ -77,7 +77,7 @@ impl JmpInstr {
 		}
 	}
 
-	fn try_optimize(&mut self) -> bool {
+	fn try_optimize(&mut self, gained: u64) -> bool {
 		if self.instr_kind == InstrKind::Unchanged || self.instr_kind == InstrKind::Short {
 			return false;
 		}
@@ -85,6 +85,7 @@ impl JmpInstr {
 		let mut target_address = self.target_instr.address(self);
 		let mut next_rip = self.ip.wrapping_add(self.short_instruction_size as u64);
 		let mut diff = target_address.wrapping_sub(next_rip) as i64;
+        diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 		if i8::MIN as i64 <= diff && diff <= i8::MAX as i64 {
 			if let Some(ref pointer_data) = self.pointer_data {
 				pointer_data.borrow_mut().is_valid = false;
@@ -100,6 +101,7 @@ impl JmpInstr {
 			target_address = self.target_instr.address(self);
 			next_rip = self.ip.wrapping_add(self.near_instruction_size as u64);
 			diff = target_address.wrapping_sub(next_rip) as i64;
+            diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 			use_near = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 		if use_near {
@@ -142,11 +144,11 @@ impl Instr for JmpInstr {
 
 	fn initialize(&mut self, block_encoder: &BlockEncoder) {
 		self.target_instr = block_encoder.get_target(self, self.instruction.near_branch_target());
-		let _ = self.try_optimize();
+		let _ = self.try_optimize(0);
 	}
 
-	fn optimize(&mut self) -> bool {
-		self.try_optimize()
+	fn optimize(&mut self, gained: u64) -> bool {
+		self.try_optimize(gained)
 	}
 
 	fn encode(&mut self, block: &mut Block) -> Result<(ConstantOffsets, bool), IcedError> {

--- a/src/rust/iced-x86/src/block_enc/instr/mod.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/mod.rs
@@ -42,7 +42,11 @@ pub(super) trait Instr {
 }
 
 fn correct_diff(in_block: bool, diff: i64, gained: u64) -> i64 {
-    if in_block && diff > gained as i64 { diff - gained as i64 } else { diff }
+	if in_block && diff > gained as i64 {
+		diff - gained as i64
+	} else {
+		diff
+	}
 }
 
 #[derive(Default)]

--- a/src/rust/iced-x86/src/block_enc/instr/mod.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/mod.rs
@@ -36,9 +36,13 @@ pub(super) trait Instr {
 	fn initialize(&mut self, block_encoder: &BlockEncoder);
 
 	/// Returns `true` if the instruction was updated to a shorter instruction, `false` if nothing changed
-	fn optimize(&mut self) -> bool;
+	fn optimize(&mut self, gained: u64) -> bool;
 
 	fn encode(&mut self, block: &mut Block) -> Result<(ConstantOffsets, bool), IcedError>;
+}
+
+fn correct_diff(in_block: bool, diff: i64, gained: u64) -> i64 {
+    if in_block && diff > gained as i64 { diff - gained as i64 } else { diff }
 }
 
 #[derive(Default)]

--- a/src/rust/iced-x86/src/block_enc/instr/mod.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/mod.rs
@@ -42,7 +42,7 @@ pub(super) trait Instr {
 }
 
 fn correct_diff(in_block: bool, diff: i64, gained: u64) -> i64 {
-	if in_block && diff > gained as i64 {
+	if in_block && diff >= gained as i64 {
 		diff - gained as i64
 	} else {
 		diff

--- a/src/rust/iced-x86/src/block_enc/instr/simple_br_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/simple_br_instr.rs
@@ -100,7 +100,7 @@ impl SimpleBranchInstr {
 		}
 	}
 
-	fn try_optimize(&mut self) -> bool {
+	fn try_optimize(&mut self, gained: u64) -> bool {
 		if self.instr_kind == InstrKind::Unchanged || self.instr_kind == InstrKind::Short {
 			return false;
 		}
@@ -108,6 +108,7 @@ impl SimpleBranchInstr {
 		let mut target_address = self.target_instr.address(self);
 		let mut next_rip = self.ip().wrapping_add(self.short_instruction_size as u64);
 		let mut diff = target_address.wrapping_sub(next_rip) as i64;
+        diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 		if i8::MIN as i64 <= diff && diff <= i8::MAX as i64 {
 			if let Some(ref pointer_data) = self.pointer_data {
 				pointer_data.borrow_mut().is_valid = false;
@@ -123,6 +124,7 @@ impl SimpleBranchInstr {
 			target_address = self.target_instr.address(self);
 			next_rip = self.ip.wrapping_add(self.near_instruction_size as u64);
 			diff = target_address.wrapping_sub(next_rip) as i64;
+            diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
 			use_near = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 		if use_near {
@@ -196,11 +198,11 @@ impl Instr for SimpleBranchInstr {
 
 	fn initialize(&mut self, block_encoder: &BlockEncoder) {
 		self.target_instr = block_encoder.get_target(self, self.instruction.near_branch_target());
-		let _ = self.try_optimize();
+		let _ = self.try_optimize(0);
 	}
 
-	fn optimize(&mut self) -> bool {
-		self.try_optimize()
+	fn optimize(&mut self, gained: u64) -> bool {
+		self.try_optimize(gained)
 	}
 
 	fn encode(&mut self, block: &mut Block) -> Result<(ConstantOffsets, bool), IcedError> {

--- a/src/rust/iced-x86/src/block_enc/instr/simple_br_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/simple_br_instr.rs
@@ -108,7 +108,7 @@ impl SimpleBranchInstr {
 		let mut target_address = self.target_instr.address(self);
 		let mut next_rip = self.ip().wrapping_add(self.short_instruction_size as u64);
 		let mut diff = target_address.wrapping_sub(next_rip) as i64;
-        diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+		diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 		if i8::MIN as i64 <= diff && diff <= i8::MAX as i64 {
 			if let Some(ref pointer_data) = self.pointer_data {
 				pointer_data.borrow_mut().is_valid = false;
@@ -124,7 +124,7 @@ impl SimpleBranchInstr {
 			target_address = self.target_instr.address(self);
 			next_rip = self.ip.wrapping_add(self.near_instruction_size as u64);
 			diff = target_address.wrapping_sub(next_rip) as i64;
-            diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+			diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 			use_near = i32::MIN as i64 <= diff && diff <= i32::MAX as i64;
 		}
 		if use_near {

--- a/src/rust/iced-x86/src/block_enc/instr/simple_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/simple_instr.rs
@@ -49,7 +49,7 @@ impl Instr for SimpleInstr {
 
 	fn initialize(&mut self, _block_encoder: &BlockEncoder) {}
 
-	fn optimize(&mut self) -> bool {
+	fn optimize(&mut self, _gained: u64) -> bool {
 		false
 	}
 

--- a/src/rust/iced-x86/src/block_enc/instr/xbegin_instr.rs
+++ b/src/rust/iced-x86/src/block_enc/instr/xbegin_instr.rs
@@ -75,7 +75,7 @@ impl XbeginInstr {
 		let target_address = self.target_instr.address(self);
 		let next_rip = self.ip.wrapping_add(self.short_instruction_size as u64);
 		let diff = target_address.wrapping_sub(next_rip) as i64;
-        let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff,  gained);
+		let diff = correct_diff(self.target_instr.is_in_block(self.block()), diff, gained);
 		if i16::MIN as i64 <= diff && diff <= i16::MAX as i64 {
 			self.instr_kind = InstrKind::Rel16;
 			self.size = self.short_instruction_size;


### PR DESCRIPTION
Fix a bug in `BlockEncoder` that caused it to optimize only around 30 forward jump instructions/block/pass, making it super slow on big blocks.