### PR TITLE
Replace raw pointers with indexes

### DIFF
--- a/src/rust/iced-x86/src/decoder.rs
+++ b/src/rust/iced-x86/src/decoder.rs
@@ -3,7 +3,7 @@
 
 macro_rules! mk_read_xx {
 	($slf:ident, $mem_ty:ty, $from_le:path, $ret_ty:ty, $err_expr:expr) => {
-		use ::std::convert::TryInto;
+		use ::core::convert::TryInto;
 		const SIZE: usize = mem::size_of::<$mem_ty>();
 		const _: () = assert!(SIZE >= 1);
 		const _: () = assert!(SIZE <= Decoder::MAX_READ_SIZE);

--- a/src/rust/iced-x86/src/decoder/handlers/legacy.rs
+++ b/src/rust/iced-x86/src/decoder/handlers/legacy.rs
@@ -3640,7 +3640,7 @@ impl OpCodeHandler_Reg_Ob {
 		debug_assert_eq!(decoder.state.encoding(), EncodingKind::Legacy as u32);
 		instruction.set_code(this.code);
 		instruction.set_op0_register(this.reg);
-		decoder.displ_index = decoder.data_ptr as u8;
+		decoder.displ_index = decoder.position() as u8;
 		//instruction_internal::internal_set_memory_index_scale(instruction, 0);
 		//instruction.set_memory_base(Register::None);
 		//instruction.set_memory_index(Register::None);
@@ -3678,7 +3678,7 @@ impl OpCodeHandler_Ob_Reg {
 		debug_assert_eq!(decoder.state.encoding(), EncodingKind::Legacy as u32);
 		instruction.set_code(this.code);
 		instruction.set_op1_register(this.reg);
-		decoder.displ_index = decoder.data_ptr as u8;
+		decoder.displ_index = decoder.position() as u8;
 		//instruction_internal::internal_set_memory_index_scale(instruction, 0);
 		//instruction.set_memory_base(Register::None);
 		//instruction.set_memory_index(Register::None);
@@ -3713,7 +3713,7 @@ impl OpCodeHandler_Reg_Ov {
 	fn decode(self_ptr: *const OpCodeHandler, decoder: &mut Decoder<'_>, instruction: &mut Instruction) {
 		let this = unsafe { &*(self_ptr as *const Self) };
 		debug_assert_eq!(decoder.state.encoding(), EncodingKind::Legacy as u32);
-		decoder.displ_index = decoder.data_ptr as u8;
+		decoder.displ_index = decoder.position() as u8;
 		instruction.set_code(this.code[decoder.state.operand_size as usize]);
 		if decoder.state.operand_size == OpSize::Size32 {
 			instruction.set_op0_register(Register::EAX);
@@ -3756,7 +3756,7 @@ impl OpCodeHandler_Ov_Reg {
 	fn decode(self_ptr: *const OpCodeHandler, decoder: &mut Decoder<'_>, instruction: &mut Instruction) {
 		let this = unsafe { &*(self_ptr as *const Self) };
 		debug_assert_eq!(decoder.state.encoding(), EncodingKind::Legacy as u32);
-		decoder.displ_index = decoder.data_ptr as u8;
+		decoder.displ_index = decoder.position() as u8;
 		instruction.set_code(this.code[decoder.state.operand_size as usize]);
 		if decoder.state.operand_size == OpSize::Size32 {
 			instruction.set_op1_register(Register::EAX);


### PR DESCRIPTION
Attemping #325 again in a safer way this time - replacing pointers entirely with indexes. This removes some of the complexity of upholding safety invariants, and removes UB in this part of the decoder.

Some light testing against https://github.com/icedland/disas-bench seems to show around 2% speed regression in the `no-fmt` benchmark of Iced - not sure if this is acceptable for the safety gains, so this is more an experimental PR.

It might be possible for some localised use of `unsafe` to bring performance up, but in my tests `mk_read_u8` generates the most optimal possible code that behaves properly already.