### PR TITLE
Serialize Rust enums as integers

### DIFF
--- a/src/rust/iced-x86/Cargo.toml
+++ b/src/rust/iced-x86/Cargo.toml
@@ -31,7 +31,7 @@ fast_fmt = []
 db = []
 std = ["lazy_static"]
 # no_std feature is needed since std and no_std require different deps
-no_std = ["lazy_static/spin_no_std", "hashbrown"]
+no_std = ["lazy_static/spin_no_std"]
 exhaustive_enums = []
 no_vex = []
 no_evex = []
@@ -46,9 +46,6 @@ __internal_flip = []
 # if: decoder or encoder or gas or intel or masm or nasm or fast_fmt
 # It's not really optional, std or no_std must be used and they both require it.
 lazy_static = { version = "1.4.0", optional = true }
-
-# if: no_std and serde
-hashbrown = { version = "0.12.3", optional = true }
 
 # If: serde 
 [dependencies.serde]

--- a/src/rust/iced-x86/README.md
+++ b/src/rust/iced-x86/README.md
@@ -56,7 +56,7 @@ You can enable/disable these in your `Cargo.toml` file.
 - `code_asm`: Enables [`CodeAssembler`] to allow easy creation of instructions, eg. `a.xor(ecx, dword_ptr(edx))` instead of using the more verbose `Instruction::with*()` methods.
 - `serde`: Enables serialization support ([`Instruction`]). Not guaranteed to work if different versions of iced was used to serialize and deserialize it.
 - `std`: (👍 Enabled by default) Enables the `std` crate. `std` or `no_std` must be defined, but not both.
-- `no_std`: Enables `#![no_std]`. `std` or `no_std` must be defined, but not both. This feature uses the `alloc` crate and the `hashbrown` crate.
+- `no_std`: Enables `#![no_std]`. `std` or `no_std` must be defined, but not both. This feature uses the `alloc` crate.
 - `mvex`: Enables `MVEX` instructions (Knights Corner). You must also pass in `DecoderOptions::KNC` to the [`Decoder`] constructor.
 - `exhaustive_enums`: Enables exhaustive enums, i.e., no enum has the `#[non_exhaustive]` attribute
 

--- a/src/rust/iced-x86/src/code.rs
+++ b/src/rust/iced-x86/src/code.rs
@@ -44257,18 +44257,9 @@ fn test_code_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	#[cfg(not(feature = "std"))]
-	use hashbrown::HashMap;
-	use lazy_static::lazy_static;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
-	#[cfg(feature = "std")]
-	use std::collections::HashMap;
-	lazy_static! {
-		static ref NAME_TO_ENUM: HashMap<&'static [u8], EnumType> = GEN_DEBUG_CODE.iter().map(|&s| s.as_bytes()).zip(EnumType::values()).collect();
-	}
 	type EnumType = Code;
 	impl Serialize for EnumType {
 		#[inline]
@@ -44276,7 +44267,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("Code", *self as u32, GEN_DEBUG_CODE[*self as usize])
+			serializer.serialize_u16(*self as u16)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -44285,64 +44276,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid Code variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					if let Some(&value) = NAME_TO_ENUM.get(v) {
-						Ok(EnumValue(value))
-					} else {
-						Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["Code enum variants"][..]))
-					}
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -44354,18 +44287,19 @@ const _: () = {
 					formatter.write_str("enum Code")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid Code variant value"))
 				}
 			}
-			deserializer.deserialize_enum("Code", &GEN_DEBUG_CODE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u16(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };

--- a/src/rust/iced-x86/src/decoder.rs
+++ b/src/rust/iced-x86/src/decoder.rs
@@ -267,9 +267,8 @@ fn test_decodererror_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = DecoderError;
 	impl Serialize for EnumType {
@@ -278,7 +277,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("DecoderError", *self as u32, GEN_DEBUG_DECODER_ERROR[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -287,65 +286,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid DecoderError variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_DECODER_ERROR.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["DecoderError enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -357,18 +297,19 @@ const _: () = {
 					formatter.write_str("enum DecoderError")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid DecoderError variant value"))
 				}
 			}
-			deserializer.deserialize_enum("DecoderError", &GEN_DEBUG_DECODER_ERROR[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };

--- a/src/rust/iced-x86/src/enums.rs
+++ b/src/rust/iced-x86/src/enums.rs
@@ -100,9 +100,8 @@ fn test_codesize_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CodeSize;
 	impl Serialize for EnumType {
@@ -111,7 +110,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CodeSize", *self as u32, GEN_DEBUG_CODE_SIZE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -120,65 +119,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CodeSize variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CODE_SIZE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CodeSize enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -190,18 +130,19 @@ const _: () = {
 					formatter.write_str("enum CodeSize")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CodeSize variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CodeSize", &GEN_DEBUG_CODE_SIZE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -304,9 +245,8 @@ fn test_roundingcontrol_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = RoundingControl;
 	impl Serialize for EnumType {
@@ -315,7 +255,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("RoundingControl", *self as u32, GEN_DEBUG_ROUNDING_CONTROL[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -324,65 +264,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid RoundingControl variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_ROUNDING_CONTROL.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["RoundingControl enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -394,18 +275,19 @@ const _: () = {
 					formatter.write_str("enum RoundingControl")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid RoundingControl variant value"))
 				}
 			}
-			deserializer.deserialize_enum("RoundingControl", &GEN_DEBUG_ROUNDING_CONTROL[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -650,9 +532,8 @@ fn test_opkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = OpKind;
 	impl Serialize for EnumType {
@@ -661,7 +542,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("OpKind", *self as u32, GEN_DEBUG_OP_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -670,65 +551,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_OP_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["OpKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -740,18 +562,19 @@ const _: () = {
 					formatter.write_str("enum OpKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("OpKind", &GEN_DEBUG_OP_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -941,9 +764,8 @@ fn test_encodingkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = EncodingKind;
 	impl Serialize for EnumType {
@@ -952,7 +774,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("EncodingKind", *self as u32, GEN_DEBUG_ENCODING_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -961,65 +783,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid EncodingKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_ENCODING_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["EncodingKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1031,18 +794,19 @@ const _: () = {
 					formatter.write_str("enum EncodingKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid EncodingKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("EncodingKind", &GEN_DEBUG_ENCODING_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1199,9 +963,8 @@ fn test_tupletype_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = TupleType;
 	impl Serialize for EnumType {
@@ -1210,7 +973,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("TupleType", *self as u32, GEN_DEBUG_TUPLE_TYPE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1219,65 +982,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid TupleType variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_TUPLE_TYPE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["TupleType enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1289,18 +993,19 @@ const _: () = {
 					formatter.write_str("enum TupleType")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid TupleType variant value"))
 				}
 			}
-			deserializer.deserialize_enum("TupleType", &GEN_DEBUG_TUPLE_TYPE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1430,9 +1135,8 @@ fn test_flowcontrol_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = FlowControl;
 	impl Serialize for EnumType {
@@ -1441,7 +1145,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("FlowControl", *self as u32, GEN_DEBUG_FLOW_CONTROL[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1450,65 +1154,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid FlowControl variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_FLOW_CONTROL.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["FlowControl enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1520,18 +1165,19 @@ const _: () = {
 					formatter.write_str("enum FlowControl")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid FlowControl variant value"))
 				}
 			}
-			deserializer.deserialize_enum("FlowControl", &GEN_DEBUG_FLOW_CONTROL[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1966,18 +1612,9 @@ fn test_opcodeoperandkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	#[cfg(not(feature = "std"))]
-	use hashbrown::HashMap;
-	use lazy_static::lazy_static;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
-	#[cfg(feature = "std")]
-	use std::collections::HashMap;
-	lazy_static! {
-		static ref NAME_TO_ENUM: HashMap<&'static [u8], EnumType> = GEN_DEBUG_OP_CODE_OPERAND_KIND.iter().map(|&s| s.as_bytes()).zip(EnumType::values()).collect();
-	}
 	type EnumType = OpCodeOperandKind;
 	impl Serialize for EnumType {
 		#[inline]
@@ -1985,7 +1622,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("OpCodeOperandKind", *self as u32, GEN_DEBUG_OP_CODE_OPERAND_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1994,64 +1631,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpCodeOperandKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					if let Some(&value) = NAME_TO_ENUM.get(v) {
-						Ok(EnumValue(value))
-					} else {
-						Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["OpCodeOperandKind enum variants"][..]))
-					}
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -2063,18 +1642,19 @@ const _: () = {
 					formatter.write_str("enum OpCodeOperandKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpCodeOperandKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("OpCodeOperandKind", &GEN_DEBUG_OP_CODE_OPERAND_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -2183,9 +1763,8 @@ fn test_mvexehbit_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = MvexEHBit;
 	impl Serialize for EnumType {
@@ -2194,7 +1773,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("MvexEHBit", *self as u32, GEN_DEBUG_MVEX_EHBIT[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -2203,65 +1782,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexEHBit variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_MVEX_EHBIT.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["MvexEHBit enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -2273,18 +1793,19 @@ const _: () = {
 					formatter.write_str("enum MvexEHBit")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexEHBit variant value"))
 				}
 			}
-			deserializer.deserialize_enum("MvexEHBit", &GEN_DEBUG_MVEX_EHBIT[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -2939,18 +2460,9 @@ fn test_cpuidfeature_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	#[cfg(not(feature = "std"))]
-	use hashbrown::HashMap;
-	use lazy_static::lazy_static;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
-	#[cfg(feature = "std")]
-	use std::collections::HashMap;
-	lazy_static! {
-		static ref NAME_TO_ENUM: HashMap<&'static [u8], EnumType> = GEN_DEBUG_CPUID_FEATURE.iter().map(|&s| s.as_bytes()).zip(EnumType::values()).collect();
-	}
 	type EnumType = CpuidFeature;
 	impl Serialize for EnumType {
 		#[inline]
@@ -2958,7 +2470,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CpuidFeature", *self as u32, GEN_DEBUG_CPUID_FEATURE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -2967,64 +2479,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CpuidFeature variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					if let Some(&value) = NAME_TO_ENUM.get(v) {
-						Ok(EnumValue(value))
-					} else {
-						Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CpuidFeature enum variants"][..]))
-					}
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3036,18 +2490,19 @@ const _: () = {
 					formatter.write_str("enum CpuidFeature")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CpuidFeature variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CpuidFeature", &GEN_DEBUG_CPUID_FEATURE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -3211,9 +2666,8 @@ fn test_opaccess_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = OpAccess;
 	impl Serialize for EnumType {
@@ -3222,7 +2676,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("OpAccess", *self as u32, GEN_DEBUG_OP_ACCESS[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -3231,65 +2685,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpAccess variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_OP_ACCESS.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["OpAccess enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3301,18 +2696,19 @@ const _: () = {
 					formatter.write_str("enum OpAccess")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpAccess variant value"))
 				}
 			}
-			deserializer.deserialize_enum("OpAccess", &GEN_DEBUG_OP_ACCESS[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -3462,9 +2858,8 @@ fn test_conditioncode_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = ConditionCode;
 	impl Serialize for EnumType {
@@ -3473,7 +2868,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("ConditionCode", *self as u32, GEN_DEBUG_CONDITION_CODE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -3482,65 +2877,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid ConditionCode variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CONDITION_CODE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["ConditionCode enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3552,18 +2888,19 @@ const _: () = {
 					formatter.write_str("enum ConditionCode")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid ConditionCode variant value"))
 				}
 			}
-			deserializer.deserialize_enum("ConditionCode", &GEN_DEBUG_CONDITION_CODE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -3676,9 +3013,8 @@ fn test_mandatoryprefix_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = MandatoryPrefix;
 	impl Serialize for EnumType {
@@ -3687,7 +3023,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("MandatoryPrefix", *self as u32, GEN_DEBUG_MANDATORY_PREFIX[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -3696,65 +3032,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MandatoryPrefix variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_MANDATORY_PREFIX.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["MandatoryPrefix enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3766,18 +3043,19 @@ const _: () = {
 					formatter.write_str("enum MandatoryPrefix")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MandatoryPrefix variant value"))
 				}
 			}
-			deserializer.deserialize_enum("MandatoryPrefix", &GEN_DEBUG_MANDATORY_PREFIX[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -3903,9 +3181,8 @@ fn test_opcodetablekind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = OpCodeTableKind;
 	impl Serialize for EnumType {
@@ -3914,7 +3191,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("OpCodeTableKind", *self as u32, GEN_DEBUG_OP_CODE_TABLE_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -3923,65 +3200,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpCodeTableKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_OP_CODE_TABLE_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["OpCodeTableKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3993,18 +3211,19 @@ const _: () = {
 					formatter.write_str("enum OpCodeTableKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid OpCodeTableKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("OpCodeTableKind", &GEN_DEBUG_OP_CODE_TABLE_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -4102,9 +3321,8 @@ fn test_instrscale_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = InstrScale;
 	impl Serialize for EnumType {
@@ -4113,7 +3331,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("InstrScale", *self as u32, GEN_DEBUG_INSTR_SCALE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -4122,65 +3340,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid InstrScale variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_INSTR_SCALE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["InstrScale enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -4192,18 +3351,19 @@ const _: () = {
 					formatter.write_str("enum InstrScale")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid InstrScale variant value"))
 				}
 			}
-			deserializer.deserialize_enum("InstrScale", &GEN_DEBUG_INSTR_SCALE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -4342,9 +3502,8 @@ fn test_mvexconvfn_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = MvexConvFn;
 	impl Serialize for EnumType {
@@ -4353,7 +3512,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("MvexConvFn", *self as u32, GEN_DEBUG_MVEX_CONV_FN[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -4362,65 +3521,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexConvFn variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_MVEX_CONV_FN.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["MvexConvFn enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -4432,18 +3532,19 @@ const _: () = {
 					formatter.write_str("enum MvexConvFn")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexConvFn variant value"))
 				}
 			}
-			deserializer.deserialize_enum("MvexConvFn", &GEN_DEBUG_MVEX_CONV_FN[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -4594,9 +3695,8 @@ fn test_mvexregmemconv_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = MvexRegMemConv;
 	impl Serialize for EnumType {
@@ -4605,7 +3705,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("MvexRegMemConv", *self as u32, GEN_DEBUG_MVEX_REG_MEM_CONV[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -4614,65 +3714,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexRegMemConv variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_MVEX_REG_MEM_CONV.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["MvexRegMemConv enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -4684,18 +3725,19 @@ const _: () = {
 					formatter.write_str("enum MvexRegMemConv")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexRegMemConv variant value"))
 				}
 			}
-			deserializer.deserialize_enum("MvexRegMemConv", &GEN_DEBUG_MVEX_REG_MEM_CONV[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -4837,9 +3879,8 @@ fn test_mvextupletypelutkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = MvexTupleTypeLutKind;
 	impl Serialize for EnumType {
@@ -4848,7 +3889,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("MvexTupleTypeLutKind", *self as u32, GEN_DEBUG_MVEX_TUPLE_TYPE_LUT_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -4857,65 +3898,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexTupleTypeLutKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_MVEX_TUPLE_TYPE_LUT_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["MvexTupleTypeLutKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -4927,18 +3909,19 @@ const _: () = {
 					formatter.write_str("enum MvexTupleTypeLutKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MvexTupleTypeLutKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("MvexTupleTypeLutKind", &GEN_DEBUG_MVEX_TUPLE_TYPE_LUT_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };

--- a/src/rust/iced-x86/src/formatter/enums.rs
+++ b/src/rust/iced-x86/src/formatter/enums.rs
@@ -100,9 +100,8 @@ fn test_numberbase_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = NumberBase;
 	impl Serialize for EnumType {
@@ -111,7 +110,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("NumberBase", *self as u32, GEN_DEBUG_NUMBER_BASE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -120,65 +119,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid NumberBase variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_NUMBER_BASE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["NumberBase enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -190,18 +130,19 @@ const _: () = {
 					formatter.write_str("enum NumberBase")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid NumberBase variant value"))
 				}
 			}
-			deserializer.deserialize_enum("NumberBase", &GEN_DEBUG_NUMBER_BASE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -343,9 +284,8 @@ fn test_prefixkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = PrefixKind;
 	impl Serialize for EnumType {
@@ -354,7 +294,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("PrefixKind", *self as u32, GEN_DEBUG_PREFIX_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -363,65 +303,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid PrefixKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_PREFIX_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["PrefixKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -433,18 +314,19 @@ const _: () = {
 					formatter.write_str("enum PrefixKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid PrefixKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("PrefixKind", &GEN_DEBUG_PREFIX_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -551,9 +433,8 @@ fn test_decoratorkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = DecoratorKind;
 	impl Serialize for EnumType {
@@ -562,7 +443,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("DecoratorKind", *self as u32, GEN_DEBUG_DECORATOR_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -571,65 +452,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid DecoratorKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_DECORATOR_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["DecoratorKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -641,18 +463,19 @@ const _: () = {
 					formatter.write_str("enum DecoratorKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid DecoratorKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("DecoratorKind", &GEN_DEBUG_DECORATOR_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -758,9 +581,8 @@ fn test_numberkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = NumberKind;
 	impl Serialize for EnumType {
@@ -769,7 +591,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("NumberKind", *self as u32, GEN_DEBUG_NUMBER_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -778,65 +600,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid NumberKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_NUMBER_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["NumberKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -848,18 +611,19 @@ const _: () = {
 					formatter.write_str("enum NumberKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid NumberKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("NumberKind", &GEN_DEBUG_NUMBER_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -995,9 +759,8 @@ fn test_cc_b_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_b;
 	impl Serialize for EnumType {
@@ -1006,7 +769,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_b", *self as u32, GEN_DEBUG_CC_B[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1015,65 +778,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_b variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_B.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_b enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1085,18 +789,19 @@ const _: () = {
 					formatter.write_str("enum CC_b")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_b variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_b", &GEN_DEBUG_CC_B[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1194,9 +899,8 @@ fn test_cc_ae_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_ae;
 	impl Serialize for EnumType {
@@ -1205,7 +909,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_ae", *self as u32, GEN_DEBUG_CC_AE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1214,65 +918,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_ae variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_AE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_ae enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1284,18 +929,19 @@ const _: () = {
 					formatter.write_str("enum CC_ae")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_ae variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_ae", &GEN_DEBUG_CC_AE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1390,9 +1036,8 @@ fn test_cc_e_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_e;
 	impl Serialize for EnumType {
@@ -1401,7 +1046,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_e", *self as u32, GEN_DEBUG_CC_E[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1410,65 +1055,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_e variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_E.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_e enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1480,18 +1066,19 @@ const _: () = {
 					formatter.write_str("enum CC_e")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_e variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_e", &GEN_DEBUG_CC_E[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1586,9 +1173,8 @@ fn test_cc_ne_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_ne;
 	impl Serialize for EnumType {
@@ -1597,7 +1183,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_ne", *self as u32, GEN_DEBUG_CC_NE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1606,65 +1192,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_ne variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_NE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_ne enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1676,18 +1203,19 @@ const _: () = {
 					formatter.write_str("enum CC_ne")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_ne variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_ne", &GEN_DEBUG_CC_NE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1782,9 +1310,8 @@ fn test_cc_be_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_be;
 	impl Serialize for EnumType {
@@ -1793,7 +1320,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_be", *self as u32, GEN_DEBUG_CC_BE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1802,65 +1329,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_be variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_BE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_be enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1872,18 +1340,19 @@ const _: () = {
 					formatter.write_str("enum CC_be")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_be variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_be", &GEN_DEBUG_CC_BE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -1978,9 +1447,8 @@ fn test_cc_a_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_a;
 	impl Serialize for EnumType {
@@ -1989,7 +1457,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_a", *self as u32, GEN_DEBUG_CC_A[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -1998,65 +1466,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_a variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_A.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_a enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -2068,18 +1477,19 @@ const _: () = {
 					formatter.write_str("enum CC_a")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_a variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_a", &GEN_DEBUG_CC_A[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -2174,9 +1584,8 @@ fn test_cc_p_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_p;
 	impl Serialize for EnumType {
@@ -2185,7 +1594,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_p", *self as u32, GEN_DEBUG_CC_P[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -2194,65 +1603,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_p variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_P.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_p enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -2264,18 +1614,19 @@ const _: () = {
 					formatter.write_str("enum CC_p")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_p variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_p", &GEN_DEBUG_CC_P[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -2370,9 +1721,8 @@ fn test_cc_np_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_np;
 	impl Serialize for EnumType {
@@ -2381,7 +1731,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_np", *self as u32, GEN_DEBUG_CC_NP[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -2390,65 +1740,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_np variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_NP.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_np enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -2460,18 +1751,19 @@ const _: () = {
 					formatter.write_str("enum CC_np")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_np variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_np", &GEN_DEBUG_CC_NP[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -2566,9 +1858,8 @@ fn test_cc_l_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_l;
 	impl Serialize for EnumType {
@@ -2577,7 +1868,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_l", *self as u32, GEN_DEBUG_CC_L[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -2586,65 +1877,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_l variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_L.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_l enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -2656,18 +1888,19 @@ const _: () = {
 					formatter.write_str("enum CC_l")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_l variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_l", &GEN_DEBUG_CC_L[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -2762,9 +1995,8 @@ fn test_cc_ge_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_ge;
 	impl Serialize for EnumType {
@@ -2773,7 +2005,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_ge", *self as u32, GEN_DEBUG_CC_GE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -2782,65 +2014,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_ge variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_GE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_ge enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -2852,18 +2025,19 @@ const _: () = {
 					formatter.write_str("enum CC_ge")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_ge variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_ge", &GEN_DEBUG_CC_GE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -2958,9 +2132,8 @@ fn test_cc_le_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_le;
 	impl Serialize for EnumType {
@@ -2969,7 +2142,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_le", *self as u32, GEN_DEBUG_CC_LE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -2978,65 +2151,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_le variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_LE.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_le enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3048,18 +2162,19 @@ const _: () = {
 					formatter.write_str("enum CC_le")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_le variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_le", &GEN_DEBUG_CC_LE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -3154,9 +2269,8 @@ fn test_cc_g_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = CC_g;
 	impl Serialize for EnumType {
@@ -3165,7 +2279,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("CC_g", *self as u32, GEN_DEBUG_CC_G[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -3174,65 +2288,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_g variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_CC_G.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["CC_g enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3244,18 +2299,19 @@ const _: () = {
 					formatter.write_str("enum CC_g")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid CC_g variant value"))
 				}
 			}
-			deserializer.deserialize_enum("CC_g", &GEN_DEBUG_CC_G[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };

--- a/src/rust/iced-x86/src/formatter/enums_shared.rs
+++ b/src/rust/iced-x86/src/formatter/enums_shared.rs
@@ -153,9 +153,8 @@ fn test_formattertextkind_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = FormatterTextKind;
 	impl Serialize for EnumType {
@@ -164,7 +163,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("FormatterTextKind", *self as u32, GEN_DEBUG_FORMATTER_TEXT_KIND[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -173,65 +172,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid FormatterTextKind variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_FORMATTER_TEXT_KIND.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["FormatterTextKind enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -243,18 +183,19 @@ const _: () = {
 					formatter.write_str("enum FormatterTextKind")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid FormatterTextKind variant value"))
 				}
 			}
-			deserializer.deserialize_enum("FormatterTextKind", &GEN_DEBUG_FORMATTER_TEXT_KIND[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };
@@ -443,9 +384,8 @@ fn test_memorysizeoptions_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
 	type EnumType = MemorySizeOptions;
 	impl Serialize for EnumType {
@@ -454,7 +394,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("MemorySizeOptions", *self as u32, GEN_DEBUG_MEMORY_SIZE_OPTIONS[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -463,65 +403,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MemorySizeOptions variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					for (&name, value) in GEN_DEBUG_MEMORY_SIZE_OPTIONS.iter().zip(EnumType::values()) {
-						if name.as_bytes() == v {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["MemorySizeOptions enum variants"][..]))
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -533,18 +414,19 @@ const _: () = {
 					formatter.write_str("enum MemorySizeOptions")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MemorySizeOptions variant value"))
 				}
 			}
-			deserializer.deserialize_enum("MemorySizeOptions", &GEN_DEBUG_MEMORY_SIZE_OPTIONS[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };

--- a/src/rust/iced-x86/src/instruction.rs
+++ b/src/rust/iced-x86/src/instruction.rs
@@ -3857,7 +3857,7 @@ const _: () = {
 	const NUM_FIELDS_BINARY: usize = 19;
 
 	#[inline]
-	fn is_human_readable(value: bool) -> bool {
+	const fn is_human_readable(value: bool) -> bool {
 		// This feature is used to test the other code paths
 		if cfg!(feature = "__internal_flip") {
 			value ^ true

--- a/src/rust/iced-x86/src/memory_size.rs
+++ b/src/rust/iced-x86/src/memory_size.rs
@@ -951,18 +951,9 @@ fn test_memorysize_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	#[cfg(not(feature = "std"))]
-	use hashbrown::HashMap;
-	use lazy_static::lazy_static;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
-	#[cfg(feature = "std")]
-	use std::collections::HashMap;
-	lazy_static! {
-		static ref NAME_TO_ENUM: HashMap<&'static [u8], EnumType> = GEN_DEBUG_MEMORY_SIZE.iter().map(|&s| s.as_bytes()).zip(EnumType::values()).collect();
-	}
 	type EnumType = MemorySize;
 	impl Serialize for EnumType {
 		#[inline]
@@ -970,7 +961,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("MemorySize", *self as u32, GEN_DEBUG_MEMORY_SIZE[*self as usize])
+			serializer.serialize_u8(*self as u8)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -979,64 +970,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MemorySize variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					if let Some(&value) = NAME_TO_ENUM.get(v) {
-						Ok(EnumValue(value))
-					} else {
-						Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["MemorySize enum variants"][..]))
-					}
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -1048,18 +981,19 @@ const _: () = {
 					formatter.write_str("enum MemorySize")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid MemorySize variant value"))
 				}
 			}
-			deserializer.deserialize_enum("MemorySize", &GEN_DEBUG_MEMORY_SIZE[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u8(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };

--- a/src/rust/iced-x86/src/mnemonic.rs
+++ b/src/rust/iced-x86/src/mnemonic.rs
@@ -3845,18 +3845,9 @@ fn test_mnemonic_try_from_usize() {
 #[rustfmt::skip]
 #[allow(clippy::zero_sized_map_values)]
 const _: () = {
-	use alloc::string::String;
 	use core::marker::PhantomData;
-	#[cfg(not(feature = "std"))]
-	use hashbrown::HashMap;
-	use lazy_static::lazy_static;
-	use serde::de::{self, VariantAccess};
+	use serde::de;
 	use serde::{Deserialize, Deserializer, Serialize, Serializer};
-	#[cfg(feature = "std")]
-	use std::collections::HashMap;
-	lazy_static! {
-		static ref NAME_TO_ENUM: HashMap<&'static [u8], EnumType> = GEN_DEBUG_MNEMONIC.iter().map(|&s| s.as_bytes()).zip(EnumType::values()).collect();
-	}
 	type EnumType = Mnemonic;
 	impl Serialize for EnumType {
 		#[inline]
@@ -3864,7 +3855,7 @@ const _: () = {
 		where
 			S: Serializer,
 		{
-			serializer.serialize_unit_variant("Mnemonic", *self as u32, GEN_DEBUG_MNEMONIC[*self as usize])
+			serializer.serialize_u16(*self as u16)
 		}
 	}
 	impl<'de> Deserialize<'de> for EnumType {
@@ -3873,64 +3864,6 @@ const _: () = {
 		where
 			D: Deserializer<'de>,
 		{
-			#[repr(transparent)]
-			struct EnumValue(EnumType);
-			struct EnumValueVisitor;
-			impl<'de> de::Visitor<'de> for EnumValueVisitor {
-				type Value = EnumValue;
-				#[inline]
-				fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-					formatter.write_str("variant identifier")
-				}
-				#[inline]
-				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
-						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
-							return Ok(EnumValue(value));
-						}
-					}
-					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid Mnemonic variant value"))
-				}
-				#[inline]
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v.as_bytes())
-				}
-				#[inline]
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: de::Error,
-				{
-					EnumValueVisitor::deserialize_name(v)
-				}
-			}
-			impl EnumValueVisitor {
-				#[inline]
-				fn deserialize_name<E>(v: &[u8]) -> Result<EnumValue, E>
-				where
-					E: de::Error,
-				{
-					if let Some(&value) = NAME_TO_ENUM.get(v) {
-						Ok(EnumValue(value))
-					} else {
-						Err(de::Error::unknown_variant(&String::from_utf8_lossy(v), &["Mnemonic enum variants"][..]))
-					}
-				}
-			}
-			impl<'de> Deserialize<'de> for EnumValue {
-				#[inline]
-				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-				where
-					D: Deserializer<'de>,
-				{
-					deserializer.deserialize_identifier(EnumValueVisitor)
-				}
-			}
 			struct Visitor<'de> {
 				marker: PhantomData<EnumType>,
 				lifetime: PhantomData<&'de ()>,
@@ -3942,18 +3875,19 @@ const _: () = {
 					formatter.write_str("enum Mnemonic")
 				}
 				#[inline]
-				fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+				fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
 				where
-					A: de::EnumAccess<'de>,
+					E: de::Error,
 				{
-					let (field, variant): (EnumValue, _) = data.variant()?;
-					match variant.unit_variant() {
-						Ok(_) => Ok(field.0),
-						Err(err) => Err(err),
+					if let Ok(v) = <usize as TryFrom<_>>::try_from(v) {
+						if let Ok(value) = <EnumType as TryFrom<_>>::try_from(v) {
+							return Ok(value);
+						}
 					}
+					Err(de::Error::invalid_value(de::Unexpected::Unsigned(v), &"a valid Mnemonic variant value"))
 				}
 			}
-			deserializer.deserialize_enum("Mnemonic", &GEN_DEBUG_MNEMONIC[..], Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
+			deserializer.deserialize_u16(Visitor { marker: PhantomData::<EnumType>, lifetime: PhantomData })
 		}
 	}
 };


### PR DESCRIPTION
This finally removes the last `HashMap` usage in the code so we can remove `hashbrown` as a dependency if `no_std + serde`.

json (de)serialization is now faster (but still slow compared to eg. bincode).

Serializing them as integers instead of strings isn't a problem. The same version of iced must be used to serialize and deserialize anything, and it's documented in the README.