### PR TITLE
Revert "Use an older version of Rust to work around a crash in 1.61+ …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,15 +177,6 @@ jobs:
         shell: bash
         run: bash build/ci-install-rust.sh
 
-      #TODO: 1.61 crashes due to a big enum: https://github.com/rust-lang/rust/issues/97222
-      - name: Use older rustc version
-        shell: bash
-        run: |
-          rustup default 1.57.0
-          rustup component add rustfmt
-          rustup component add clippy
-          rustup target add wasm32-unknown-unknown
-
       - uses: actions/setup-node@v3
         with:
           node-version: ${{env.CI_NODE_MIN_VER}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,15 +133,6 @@ jobs:
         shell: bash
         run: bash build/ci-install-rust.sh
 
-      #TODO: 1.61 crashes due to a big enum: https://github.com/rust-lang/rust/issues/97222
-      - name: Use older rustc version
-        shell: bash
-        run: |
-          rustup default 1.57.0
-          rustup component add rustfmt
-          rustup component add clippy
-          rustup target add wasm32-unknown-unknown
-
       - uses: actions/setup-node@v3
         with:
           node-version: ${{env.CI_NODE_MIN_VER}}


### PR DESCRIPTION
…(#297)"

This reverts commit dc901cfe22b9bc725438456ce66bd29af05ec679.

Closes #298