### PR TITLE
Fix asan leaks

### DIFF
--- a/src/rust/iced-x86/src/formatter/fast/fmt_tbl.rs
+++ b/src/rust/iced-x86/src/formatter/fast/fmt_tbl.rs
@@ -7,7 +7,6 @@ use crate::formatter::fast::fmt_data::FORMATTER_TBL_DATA;
 use crate::formatter::fast::{FastStringMnemonic, FmtTableData};
 use crate::formatter::strings_data::*;
 use crate::iced_constants::IcedConstants;
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::convert::TryInto;
 use lazy_static::lazy_static;
@@ -69,7 +68,7 @@ fn read() -> FmtTableData {
 			new_vec.push(b'v');
 			new_vec.extend(old_str.get_slice().iter().copied().chain(core::iter::repeat(b' ')).take(FastStringMnemonic::SIZE - 1));
 			debug_assert_eq!(new_vec.len(), 1 + FastStringMnemonic::SIZE);
-			let len_data = Box::leak(Box::new(new_vec)).as_ptr();
+			let len_data = new_vec.leak().as_ptr();
 			FastStringMnemonic::new(len_data)
 		} else {
 			strings[reader.read_compressed_u32() as usize]

--- a/src/rust/iced-x86/src/formatter/fast/pseudo_ops_fast.rs
+++ b/src/rust/iced-x86/src/formatter/fast/pseudo_ops_fast.rs
@@ -5,7 +5,6 @@
 
 use crate::formatter::enums_shared::PseudoOpsKind;
 use crate::formatter::fast::FastStringMnemonic;
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 use lazy_static::lazy_static;
 
@@ -263,7 +262,7 @@ fn create(cc: &[&str], size: usize, prefix: &str, suffix: &str) -> Vec<FastStrin
 		new_vec.extend_from_slice(suffix.as_bytes());
 		new_vec.extend(core::iter::repeat(b' ').take(FastStringMnemonic::SIZE - (new_vec.len() - 1)));
 		debug_assert_eq!(new_vec.len(), 1 + FastStringMnemonic::SIZE);
-		let len_data = Box::leak(Box::new(new_vec)).as_ptr();
+		let len_data = new_vec.leak().as_ptr();
 		strings.push(FastStringMnemonic::new(len_data));
 	}
 	strings

--- a/src/rust/iced-x86/src/test_utils/mod.rs
+++ b/src/rust/iced-x86/src/test_utils/mod.rs
@@ -10,16 +10,10 @@ use crate::iced_constants::IcedConstants;
 use crate::test_utils::decoder_constants::*;
 use crate::Decoder;
 use core::cmp;
-use std::env;
 use std::path::PathBuf;
 
 fn get_unit_tests_base_dir() -> PathBuf {
-	let mut path = env::current_exe().expect("Couldn't get the path of the current executable");
-	for _ in 0..5 {
-		let _ = path.pop();
-	}
-	path.extend(["UnitTests", "Intel"]);
-	path
+	PathBuf::from("../../UnitTests/Intel")
 }
 
 pub(crate) fn get_instruction_unit_tests_dir() -> PathBuf {


### PR DESCRIPTION
See #524 

Before:

AddressSanitizer: 17376 byte(s) leaked in 713 allocation(s).

After: 

AddressSanitizer: 552 byte(s) leaked in 12 allocation(s).

<details>
<summary>Detailed Output</summary>

```
Direct leak of 144 byte(s) in 2 object(s) allocated from:
    #0 0x55b777c590ef in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x55b779634feb in std::sys::pal::unix::alloc::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h310c051ff3aae801 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/alloc.rs:14:13
    #2 0x55b7796f86ac in __rdl_alloc /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:394:13
    #3 0x55b77931bf64 in alloc::alloc::Global::alloc_impl::h42a729daa5eb8c82 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:181:73
    #4 0x55b77931cbd8 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h4ad6082364e7ba01 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:241:9
    #5 0x55b777de5863 in iced_x86::decoder::table_de::TableDeserializer::read_handlers::h23e82a9a58f0d245 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:220:4
    #6 0x55b777de4a3f in iced_x86::decoder::table_de::TableDeserializer::deserialize::hd5a586e30d0f5b35 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:74:16
    #7 0x55b777de73e4 in iced_x86::decoder::table_de::read_vex::h9727ca952e761a16 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:328:2
    #8 0x55b7791f45c7 in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__static_ref_initialize::h37f098c15f7aeb15 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/handlers/tables.rs:98:84
    #9 0x55b7791f45c7 in core::ops::function::FnOnce::call_once::h4803990160f2cd86 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
    #10 0x55b77901edda in lazy_static::lazy::Lazy$LT$T$GT$::get::_$u7b$$u7b$closure$u7d$$u7d$::h7643b4ded932c485 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:31:29
    #11 0x55b777d090c0 in std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::hea9c25c4d2ffb316 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:41
    #12 0x55b777d00cd5 in std::sync::once::Once::call_once::h95ca37500f55079d /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:9
    #13 0x55b778f54faa in lazy_static::lazy::Lazy$LT$T$GT$::get::h3443f99aea800fbd /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:30:9
    #14 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__stability::h4a76cda5dfd4b703 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:142:21
    #15 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::hbcdc4480ed90e03f /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:144:17
    #16 0x55b778da918f in iced_x86::decoder::Decoder::try_with_ip::h9ae1a01ccdcedd0a /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:921:17
    #17 0x55b778da8b76 in iced_x86::decoder::Decoder::with_ip::h58ae3e4117cae9f2 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:741:3
    #18 0x55b77805e9df in iced_x86::test_utils::create_decoder::hf1273f9a84bdc5e9 /home/zach/tmp/iced/src/rust/iced-x86/src/test_utils/mod.rs:62:16
    #19 0x55b7791c89bc in iced_x86::block_enc::tests::decode::he8daaaa237b5b32c /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:32:20
    #20 0x55b7791c946e in iced_x86::block_enc::tests::encode_test::haeba1f43db64ebe8 /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:54:20
    #21 0x55b777e8cbd9 in iced_x86::block_enc::tests::br8_16::br8_bwd::hdbff956b56d666cd /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:157:2
    #22 0x55b779152916 in iced_x86::block_enc::tests::br8_16::br8_bwd::_$u7b$$u7b$closure$u7d$$u7d$::hc61979c44dcd36cc /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:91:13
    #23 0x55b7794b1f9a in test::types::RunnableTest::run::hc6b8975af12476e6 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/types.rs:146:40
    #24 0x55b779405ab2 in test::run_test_in_process::_$u7b$$u7b$closure$u7d$$u7d$::he60567bdee4b3bfa /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:643:60
    #25 0x55b779408452 in _$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::ha2732eed39d545cb /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
    #26 0x55b77945683e in std::panicking::try::do_call::hb9696fddaa3bed51 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:555:40
    #27 0x55b77946a37a in __rust_try test.5cc4cd9604c85be8-cgu.11
    #28 0x55b77939bcdd in std::panic::catch_unwind::hd58cb45d1d2336d7 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:142:14
    #29 0x55b779403bf4 in test::run_test::_$u7b$$u7b$closure$u7d$$u7d$::h3249b5bab78309b8 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:566:43
    #30 0x55b7794043af in test::run_test::_$u7b$$u7b$closure$u7d$$u7d$::h74aabe25cb328b29 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:594:41
    #31 0x55b7793c747d in std::sys_common::backtrace::__rust_begin_short_backtrace::hb161bd78fd14fe82 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs:155:18
    #32 0x55b77939bd1d in std::panic::catch_unwind::hf8c840e0746c5999 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:142:14

Indirect leak of 144 byte(s) in 2 object(s) allocated from:
    #0 0x55b777c590ef in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x55b779634feb in std::sys::pal::unix::alloc::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h310c051ff3aae801 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/alloc.rs:14:13
    #2 0x55b7796f86ac in __rdl_alloc /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:394:13
    #3 0x55b77931bf64 in alloc::alloc::Global::alloc_impl::h42a729daa5eb8c82 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:181:73
    #4 0x55b77931cbd8 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h4ad6082364e7ba01 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:241:9
    #5 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #6 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #7 0x55b777de5863 in iced_x86::decoder::table_de::TableDeserializer::read_handlers::h23e82a9a58f0d245 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:220:4
    #8 0x55b777de4a3f in iced_x86::decoder::table_de::TableDeserializer::deserialize::hd5a586e30d0f5b35 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:74:16
    #9 0x55b777de73e4 in iced_x86::decoder::table_de::read_vex::h9727ca952e761a16 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:328:2
    #10 0x55b7791f45c7 in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__static_ref_initialize::h37f098c15f7aeb15 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/handlers/tables.rs:98:84
    #11 0x55b7791f45c7 in core::ops::function::FnOnce::call_once::h4803990160f2cd86 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
    #12 0x55b77901edda in lazy_static::lazy::Lazy$LT$T$GT$::get::_$u7b$$u7b$closure$u7d$$u7d$::h7643b4ded932c485 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:31:29
    #13 0x55b777d090c0 in std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::hea9c25c4d2ffb316 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:41
    #14 0x55b777d00cd5 in std::sync::once::Once::call_once::h95ca37500f55079d /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:9
    #15 0x55b778f54faa in lazy_static::lazy::Lazy$LT$T$GT$::get::h3443f99aea800fbd /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:30:9
    #16 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__stability::h4a76cda5dfd4b703 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:142:21
    #17 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::hbcdc4480ed90e03f /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:144:17
    #18 0x55b778da918f in iced_x86::decoder::Decoder::try_with_ip::h9ae1a01ccdcedd0a /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:921:17
    #19 0x55b778da8b76 in iced_x86::decoder::Decoder::with_ip::h58ae3e4117cae9f2 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:741:3
    #20 0x55b77805e9df in iced_x86::test_utils::create_decoder::hf1273f9a84bdc5e9 /home/zach/tmp/iced/src/rust/iced-x86/src/test_utils/mod.rs:62:16
    #21 0x55b7791c89bc in iced_x86::block_enc::tests::decode::he8daaaa237b5b32c /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:32:20
    #22 0x55b7791c946e in iced_x86::block_enc::tests::encode_test::haeba1f43db64ebe8 /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:54:20
    #23 0x55b777e8cbd9 in iced_x86::block_enc::tests::br8_16::br8_bwd::hdbff956b56d666cd /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:157:2
    #24 0x55b779152916 in iced_x86::block_enc::tests::br8_16::br8_bwd::_$u7b$$u7b$closure$u7d$$u7d$::hc61979c44dcd36cc /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:91:13
    #25 0x55b7794b1f9a in test::types::RunnableTest::run::hc6b8975af12476e6 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/types.rs:146:40
    #26 0x55b779405ab2 in test::run_test_in_process::_$u7b$$u7b$closure$u7d$$u7d$::he60567bdee4b3bfa /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:643:60
    #27 0x55b779408452 in _$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::ha2732eed39d545cb /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
    #28 0x55b77945683e in std::panicking::try::do_call::hb9696fddaa3bed51 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:555:40
    #29 0x55b77946a37a in __rust_try test.5cc4cd9604c85be8-cgu.11
    #30 0x55b77939bcdd in std::panic::catch_unwind::hd58cb45d1d2336d7 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:142:14
    #31 0x55b779403bf4 in test::run_test::_$u7b$$u7b$closure$u7d$$u7d$::h3249b5bab78309b8 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:566:43
    #32 0x55b7794043af in test::run_test::_$u7b$$u7b$closure$u7d$$u7d$::h74aabe25cb328b29 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:594:41

Indirect leak of 96 byte(s) in 2 object(s) allocated from:
    #0 0x55b777c590ef in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x55b779634feb in std::sys::pal::unix::alloc::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h310c051ff3aae801 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/alloc.rs:14:13
    #2 0x55b7796f86ac in __rdl_alloc /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:394:13
    #3 0x55b77931bf64 in alloc::alloc::Global::alloc_impl::h42a729daa5eb8c82 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:181:73
    #4 0x55b77931cbd8 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h4ad6082364e7ba01 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:241:9
    #5 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #6 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #7 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #8 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #9 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #10 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #11 0x55b777de5863 in iced_x86::decoder::table_de::TableDeserializer::read_handlers::h23e82a9a58f0d245 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:220:4
    #12 0x55b777de4a3f in iced_x86::decoder::table_de::TableDeserializer::deserialize::hd5a586e30d0f5b35 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:74:16
    #13 0x55b777de73e4 in iced_x86::decoder::table_de::read_vex::h9727ca952e761a16 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:328:2
    #14 0x55b7791f45c7 in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__static_ref_initialize::h37f098c15f7aeb15 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/handlers/tables.rs:98:84
    #15 0x55b7791f45c7 in core::ops::function::FnOnce::call_once::h4803990160f2cd86 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
    #16 0x55b77901edda in lazy_static::lazy::Lazy$LT$T$GT$::get::_$u7b$$u7b$closure$u7d$$u7d$::h7643b4ded932c485 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:31:29
    #17 0x55b777d090c0 in std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::hea9c25c4d2ffb316 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:41
    #18 0x55b777d00cd5 in std::sync::once::Once::call_once::h95ca37500f55079d /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:9
    #19 0x55b778f54faa in lazy_static::lazy::Lazy$LT$T$GT$::get::h3443f99aea800fbd /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:30:9
    #20 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__stability::h4a76cda5dfd4b703 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:142:21
    #21 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::hbcdc4480ed90e03f /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:144:17
    #22 0x55b778da918f in iced_x86::decoder::Decoder::try_with_ip::h9ae1a01ccdcedd0a /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:921:17
    #23 0x55b778da8b76 in iced_x86::decoder::Decoder::with_ip::h58ae3e4117cae9f2 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:741:3
    #24 0x55b77805e9df in iced_x86::test_utils::create_decoder::hf1273f9a84bdc5e9 /home/zach/tmp/iced/src/rust/iced-x86/src/test_utils/mod.rs:62:16
    #25 0x55b7791c89bc in iced_x86::block_enc::tests::decode::he8daaaa237b5b32c /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:32:20
    #26 0x55b7791c946e in iced_x86::block_enc::tests::encode_test::haeba1f43db64ebe8 /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:54:20
    #27 0x55b777e8cbd9 in iced_x86::block_enc::tests::br8_16::br8_bwd::hdbff956b56d666cd /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:157:2
    #28 0x55b779152916 in iced_x86::block_enc::tests::br8_16::br8_bwd::_$u7b$$u7b$closure$u7d$$u7d$::hc61979c44dcd36cc /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:91:13
    #29 0x55b7794b1f9a in test::types::RunnableTest::run::hc6b8975af12476e6 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/types.rs:146:40
    #30 0x55b779405ab2 in test::run_test_in_process::_$u7b$$u7b$closure$u7d$$u7d$::he60567bdee4b3bfa /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:643:60
    #31 0x55b779408452 in _$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::ha2732eed39d545cb /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
    #32 0x55b77945683e in std::panicking::try::do_call::hb9696fddaa3bed51 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:555:40

Indirect leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x55b777c590ef in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x55b779634feb in std::sys::pal::unix::alloc::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h310c051ff3aae801 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/alloc.rs:14:13
    #2 0x55b7796f86ac in __rdl_alloc /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:394:13
    #3 0x55b77931bf64 in alloc::alloc::Global::alloc_impl::h42a729daa5eb8c82 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:181:73
    #4 0x55b77931cbd8 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h4ad6082364e7ba01 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:241:9
    #5 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #6 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #7 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #8 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #9 0x55b777de5863 in iced_x86::decoder::table_de::TableDeserializer::read_handlers::h23e82a9a58f0d245 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:220:4
    #10 0x55b777de4a3f in iced_x86::decoder::table_de::TableDeserializer::deserialize::hd5a586e30d0f5b35 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:74:16
    #11 0x55b777de73e4 in iced_x86::decoder::table_de::read_vex::h9727ca952e761a16 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:328:2
    #12 0x55b7791f45c7 in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__static_ref_initialize::h37f098c15f7aeb15 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/handlers/tables.rs:98:84
    #13 0x55b7791f45c7 in core::ops::function::FnOnce::call_once::h4803990160f2cd86 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
    #14 0x55b77901edda in lazy_static::lazy::Lazy$LT$T$GT$::get::_$u7b$$u7b$closure$u7d$$u7d$::h7643b4ded932c485 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:31:29
    #15 0x55b777d090c0 in std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::hea9c25c4d2ffb316 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:41
    #16 0x55b777d00cd5 in std::sync::once::Once::call_once::h95ca37500f55079d /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:9
    #17 0x55b778f54faa in lazy_static::lazy::Lazy$LT$T$GT$::get::h3443f99aea800fbd /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:30:9
    #18 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__stability::h4a76cda5dfd4b703 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:142:21
    #19 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::hbcdc4480ed90e03f /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:144:17
    #20 0x55b778da918f in iced_x86::decoder::Decoder::try_with_ip::h9ae1a01ccdcedd0a /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:921:17
    #21 0x55b778da8b76 in iced_x86::decoder::Decoder::with_ip::h58ae3e4117cae9f2 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:741:3
    #22 0x55b77805e9df in iced_x86::test_utils::create_decoder::hf1273f9a84bdc5e9 /home/zach/tmp/iced/src/rust/iced-x86/src/test_utils/mod.rs:62:16
    #23 0x55b7791c89bc in iced_x86::block_enc::tests::decode::he8daaaa237b5b32c /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:32:20
    #24 0x55b7791c946e in iced_x86::block_enc::tests::encode_test::haeba1f43db64ebe8 /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:54:20
    #25 0x55b777e8cbd9 in iced_x86::block_enc::tests::br8_16::br8_bwd::hdbff956b56d666cd /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:157:2
    #26 0x55b779152916 in iced_x86::block_enc::tests::br8_16::br8_bwd::_$u7b$$u7b$closure$u7d$$u7d$::hc61979c44dcd36cc /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:91:13
    #27 0x55b7794b1f9a in test::types::RunnableTest::run::hc6b8975af12476e6 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/types.rs:146:40
    #28 0x55b779405ab2 in test::run_test_in_process::_$u7b$$u7b$closure$u7d$$u7d$::he60567bdee4b3bfa /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:643:60
    #29 0x55b779408452 in _$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::ha2732eed39d545cb /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
    #30 0x55b77945683e in std::panicking::try::do_call::hb9696fddaa3bed51 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:555:40
    #31 0x55b77946a37a in __rust_try test.5cc4cd9604c85be8-cgu.11
    #32 0x55b77939bcdd in std::panic::catch_unwind::hd58cb45d1d2336d7 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:142:14

Indirect leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x55b777c590ef in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x55b779634feb in std::sys::pal::unix::alloc::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h310c051ff3aae801 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/alloc.rs:14:13
    #2 0x55b7796f86ac in __rdl_alloc /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:394:13
    #3 0x55b77931bf64 in alloc::alloc::Global::alloc_impl::h42a729daa5eb8c82 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:181:73
    #4 0x55b77931cbd8 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h4ad6082364e7ba01 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:241:9
    #5 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #6 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #7 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #8 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #9 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #10 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #11 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #12 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #13 0x55b777de5863 in iced_x86::decoder::table_de::TableDeserializer::read_handlers::h23e82a9a58f0d245 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:220:4
    #14 0x55b777de4a3f in iced_x86::decoder::table_de::TableDeserializer::deserialize::hd5a586e30d0f5b35 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:74:16
    #15 0x55b777de73e4 in iced_x86::decoder::table_de::read_vex::h9727ca952e761a16 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:328:2
    #16 0x55b7791f45c7 in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__static_ref_initialize::h37f098c15f7aeb15 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/handlers/tables.rs:98:84
    #17 0x55b7791f45c7 in core::ops::function::FnOnce::call_once::h4803990160f2cd86 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
    #18 0x55b77901edda in lazy_static::lazy::Lazy$LT$T$GT$::get::_$u7b$$u7b$closure$u7d$$u7d$::h7643b4ded932c485 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:31:29
    #19 0x55b777d090c0 in std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::hea9c25c4d2ffb316 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:41
    #20 0x55b777d00cd5 in std::sync::once::Once::call_once::h95ca37500f55079d /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:9
    #21 0x55b778f54faa in lazy_static::lazy::Lazy$LT$T$GT$::get::h3443f99aea800fbd /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:30:9
    #22 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__stability::h4a76cda5dfd4b703 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:142:21
    #23 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::hbcdc4480ed90e03f /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:144:17
    #24 0x55b778da918f in iced_x86::decoder::Decoder::try_with_ip::h9ae1a01ccdcedd0a /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:921:17
    #25 0x55b778da8b76 in iced_x86::decoder::Decoder::with_ip::h58ae3e4117cae9f2 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:741:3
    #26 0x55b77805e9df in iced_x86::test_utils::create_decoder::hf1273f9a84bdc5e9 /home/zach/tmp/iced/src/rust/iced-x86/src/test_utils/mod.rs:62:16
    #27 0x55b7791c89bc in iced_x86::block_enc::tests::decode::he8daaaa237b5b32c /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:32:20
    #28 0x55b7791c946e in iced_x86::block_enc::tests::encode_test::haeba1f43db64ebe8 /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:54:20
    #29 0x55b777e8cbd9 in iced_x86::block_enc::tests::br8_16::br8_bwd::hdbff956b56d666cd /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:157:2
    #30 0x55b779152916 in iced_x86::block_enc::tests::br8_16::br8_bwd::_$u7b$$u7b$closure$u7d$$u7d$::hc61979c44dcd36cc /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:91:13
    #31 0x55b7794b1f9a in test::types::RunnableTest::run::hc6b8975af12476e6 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/types.rs:146:40
    #32 0x55b779405ab2 in test::run_test_in_process::_$u7b$$u7b$closure$u7d$$u7d$::he60567bdee4b3bfa /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/lib.rs:643:60

Indirect leak of 8 byte(s) in 2 object(s) allocated from:
    #0 0x55b777c590ef in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x55b779634feb in std::sys::pal::unix::alloc::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h310c051ff3aae801 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/pal/unix/alloc.rs:14:13
    #2 0x55b7796f86ac in __rdl_alloc /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:394:13
    #3 0x55b77931bf64 in alloc::alloc::Global::alloc_impl::h42a729daa5eb8c82 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:181:73
    #4 0x55b77931cbd8 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h4ad6082364e7ba01 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:241:9
    #5 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #6 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #7 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #8 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #9 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #10 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #11 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #12 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #13 0x55b777de5147 in iced_x86::decoder::table_de::TableDeserializer::read_handler_or_null_instance::hbf9e6721eb38fc14 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:206:3
    #14 0x55b777de4ecd in iced_x86::decoder::table_de::TableDeserializer::read_handler::h28145238c31ad462 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:196:16
    #15 0x55b777de5863 in iced_x86::decoder::table_de::TableDeserializer::read_handlers::h23e82a9a58f0d245 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:220:4
    #16 0x55b777de4a3f in iced_x86::decoder::table_de::TableDeserializer::deserialize::hd5a586e30d0f5b35 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:74:16
    #17 0x55b777de73e4 in iced_x86::decoder::table_de::read_vex::h9727ca952e761a16 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/table_de/mod.rs:328:2
    #18 0x55b7791f45c7 in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__static_ref_initialize::h37f098c15f7aeb15 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder/handlers/tables.rs:98:84
    #19 0x55b7791f45c7 in core::ops::function::FnOnce::call_once::h4803990160f2cd86 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
    #20 0x55b77901edda in lazy_static::lazy::Lazy$LT$T$GT$::get::_$u7b$$u7b$closure$u7d$$u7d$::h7643b4ded932c485 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:31:29
    #21 0x55b777d090c0 in std::sync::once::Once::call_once::_$u7b$$u7b$closure$u7d$$u7d$::hea9c25c4d2ffb316 /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:41
    #22 0x55b777d00cd5 in std::sync::once::Once::call_once::h95ca37500f55079d /home/zach/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/once.rs:149:9
    #23 0x55b778f54faa in lazy_static::lazy::Lazy$LT$T$GT$::get::h3443f99aea800fbd /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/inline_lazy.rs:30:9
    #24 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::__stability::h4a76cda5dfd4b703 /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:142:21
    #25 0x55b778f54faa in _$LT$iced_x86..decoder..handlers..tables..TABLES$u20$as$u20$core..ops..deref..Deref$GT$::deref::hbcdc4480ed90e03f /home/zach/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lazy_static-1.4.0/src/lib.rs:144:17
    #26 0x55b778da918f in iced_x86::decoder::Decoder::try_with_ip::h9ae1a01ccdcedd0a /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:921:17
    #27 0x55b778da8b76 in iced_x86::decoder::Decoder::with_ip::h58ae3e4117cae9f2 /home/zach/tmp/iced/src/rust/iced-x86/src/decoder.rs:741:3
    #28 0x55b77805e9df in iced_x86::test_utils::create_decoder::hf1273f9a84bdc5e9 /home/zach/tmp/iced/src/rust/iced-x86/src/test_utils/mod.rs:62:16
    #29 0x55b7791c89bc in iced_x86::block_enc::tests::decode::he8daaaa237b5b32c /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:32:20
    #30 0x55b7791c946e in iced_x86::block_enc::tests::encode_test::haeba1f43db64ebe8 /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/mod.rs:54:20
    #31 0x55b777e8cbd9 in iced_x86::block_enc::tests::br8_16::br8_bwd::hdbff956b56d666cd /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:157:2
    #32 0x55b779152916 in iced_x86::block_enc::tests::br8_16::br8_bwd::_$u7b$$u7b$closure$u7d$$u7d$::hc61979c44dcd36cc /home/zach/tmp/iced/src/rust/iced-x86/src/block_enc/tests/br8_16.rs:91:13

SUMMARY: AddressSanitizer: 552 byte(s) leaked in 12 allocation(s).
```
</details>

There are still some leaks to find and fix, but this is better than before