### PR TITLE
Fix spelling errors

### DIFF
--- a/src/csharp/Intel/Generator/Tables/InstructionDef.cs
+++ b/src/csharp/Intel/Generator/Tables/InstructionDef.cs
@@ -43,7 +43,7 @@ namespace Generator.Tables {
 		/// </summary>
 		Cpl3					= 0x00000040,
 		/// <summary>
-		/// It reads/writes too many registers
+		/// It reads/writes to many registers
 		/// </summary>
 		SaveRestore				= 0x00000080,
 		/// <summary>

--- a/src/csharp/Intel/Iced/Intel/Instruction.Info.cs
+++ b/src/csharp/Intel/Iced/Intel/Instruction.Info.cs
@@ -299,7 +299,7 @@ namespace Iced.Intel {
 		}
 
 		/// <summary>
-		/// <see langword="true"/> if it's an instruction that saves or restores too many registers (eg. <c>FXRSTOR</c>, <c>XSAVE</c>, etc).
+		/// <see langword="true"/> if it's an instruction that saves or restores many registers (eg. <c>FXRSTOR</c>, <c>XSAVE</c>, etc).
 		/// </summary>
 		public readonly bool IsSaveRestoreInstruction {
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/csharp/Intel/Iced/Intel/InstructionInfoExtensions.1.cs
+++ b/src/csharp/Intel/Iced/Intel/InstructionInfoExtensions.1.cs
@@ -83,7 +83,7 @@ namespace Iced.Intel {
 		}
 
 		/// <summary>
-		/// Checks if it's an instruction that saves or restores too many registers (eg. <c>FXRSTOR</c>, <c>XSAVE</c>, etc).
+		/// Checks if it's an instruction that saves or restores many registers (eg. <c>FXRSTOR</c>, <c>XSAVE</c>, etc).
 		/// </summary>
 		/// <param name="code">Code value</param>
 		/// <returns></returns>

--- a/src/csharp/Intel/Iced/Intel/OpCodeInfo.cs
+++ b/src/csharp/Intel/Iced/Intel/OpCodeInfo.cs
@@ -625,7 +625,7 @@ namespace Iced.Intel {
 		public bool IsPrivileged => (opcFlags1 & OpCodeInfoFlags1.Privileged) != 0;
 
 		/// <summary>
-		/// <see langword="true"/> if it reads/writes too many registers
+		/// <see langword="true"/> if it reads/writes to many registers
 		/// </summary>
 		public bool IsSaveRestore => (opcFlags1 & OpCodeInfoFlags1.SaveRestore) != 0;
 

--- a/src/java/iced-x86/src/main/java/com/github/icedland/iced/x86/Code.java
+++ b/src/java/iced-x86/src/main/java/com/github/icedland/iced/x86/Code.java
@@ -149,7 +149,7 @@ public final class Code {
 	}
 
 	/**
-	 * Checks if it's an instruction that saves or restores too many registers (eg.<!-- --> {@code FXRSTOR}, {@code XSAVE}, etc).
+	 * Checks if it's an instruction that saves or restores many registers (eg.<!-- --> {@code FXRSTOR}, {@code XSAVE}, etc).
 	 *
 	 * @param code Code value (a {@link Code} enum variant)
 	 */

--- a/src/java/iced-x86/src/main/java/com/github/icedland/iced/x86/Instruction.java
+++ b/src/java/iced-x86/src/main/java/com/github/icedland/iced/x86/Instruction.java
@@ -2345,7 +2345,7 @@ public final class Instruction {
 	}
 
 	/**
-	 * {@code true} if it's an instruction that saves or restores too many registers (eg.<!-- --> {@code FXRSTOR}, {@code XSAVE}, etc).
+	 * {@code true} if it's an instruction that saves or restores many registers (eg.<!-- --> {@code FXRSTOR}, {@code XSAVE}, etc).
 	 */
 	public boolean isSaveRestoreInstruction() {
 		return Code.isSaveRestoreInstruction(getCode());

--- a/src/java/iced-x86/src/main/java/com/github/icedland/iced/x86/info/OpCodeInfo.java
+++ b/src/java/iced-x86/src/main/java/com/github/icedland/iced/x86/info/OpCodeInfo.java
@@ -822,7 +822,7 @@ public final class OpCodeInfo {
 	}
 
 	/**
-	 * {@code true} if it reads/writes too many registers
+	 * {@code true} if it reads/writes to many registers
 	 */
 	public boolean isSaveRestore() {
 		return (opcFlags1 & OpCodeInfoFlags1.SAVE_RESTORE) != 0;

--- a/src/rust/iced-x86-js/src/instruction.rs
+++ b/src/rust/iced-x86-js/src/instruction.rs
@@ -1959,7 +1959,7 @@ impl Instruction {
 		self.0.is_stack_instruction()
 	}
 
-	/// `true` if it's an instruction that saves or restores too many registers (eg. `FXRSTOR`, `XSAVE`, etc).
+	/// `true` if it's an instruction that saves or restores many registers (eg. `FXRSTOR`, `XSAVE`, etc).
 	#[wasm_bindgen(getter)]
 	#[wasm_bindgen(js_name = "isSaveRestoreInstruction")]
 	pub fn is_save_restore_instruction(&self) -> bool {

--- a/src/rust/iced-x86-js/src/op_code_info.rs
+++ b/src/rust/iced-x86-js/src/op_code_info.rs
@@ -586,7 +586,7 @@ impl OpCodeInfo {
 		self.0.is_privileged()
 	}
 
-	/// `true` if it reads/writes too many registers
+	/// `true` if it reads/writes to many registers
 	#[wasm_bindgen(getter)]
 	#[wasm_bindgen(js_name = "isSaveRestore")]
 	pub fn is_save_restore(&self) -> bool {

--- a/src/rust/iced-x86-lua/lua/types/iced_x86/Instruction.lua
+++ b/src/rust/iced-x86-lua/lua/types/iced_x86/Instruction.lua
@@ -1216,7 +1216,7 @@ function Instruction:is_privileged() end
 ---```
 function Instruction:is_stack_instruction() end
 
----`true` if it's an instruction that saves or restores too many registers (eg. `FXRSTOR`, `XSAVE`, etc).
+---`true` if it's an instruction that saves or restores many registers (eg. `FXRSTOR`, `XSAVE`, etc).
 ---
 ---@return boolean
 function Instruction:is_save_restore_instruction() end

--- a/src/rust/iced-x86-lua/lua/types/iced_x86/OpCodeInfo.lua
+++ b/src/rust/iced-x86-lua/lua/types/iced_x86/OpCodeInfo.lua
@@ -410,7 +410,7 @@ function OpCodeInfo:requires_unique_dest_reg_num() end
 ---@return boolean
 function OpCodeInfo:is_privileged() end
 
----`true` if it reads/writes too many registers
+---`true` if it reads/writes to many registers
 ---
 ---@return boolean
 function OpCodeInfo:is_save_restore() end

--- a/src/rust/iced-x86-lua/src/instr.rs
+++ b/src/rust/iced-x86-lua/src/instr.rs
@@ -1410,7 +1410,7 @@ lua_pub_methods! { static INSTRUCTION_EXPORTS =>
 		unsafe { lua.push(this.inner.is_stack_instruction()); }
 	}
 
-	/// `true` if it's an instruction that saves or restores too many registers (eg. `FXRSTOR`, `XSAVE`, etc).
+	/// `true` if it's an instruction that saves or restores many registers (eg. `FXRSTOR`, `XSAVE`, etc).
 	/// @return boolean
 	unsafe fn is_save_restore_instruction(lua, this: &Instruction) -> 1 {
 		unsafe { lua.push(this.inner.is_save_restore_instruction()); }

--- a/src/rust/iced-x86-lua/src/opci.rs
+++ b/src/rust/iced-x86-lua/src/opci.rs
@@ -518,7 +518,7 @@ lua_pub_methods! { static OP_CODE_INFO_EXPORTS =>
 		unsafe { lua.push(this.inner.is_privileged()); }
 	}
 
-	/// `true` if it reads/writes too many registers
+	/// `true` if it reads/writes to many registers
 	/// @return boolean
 	unsafe fn is_save_restore(lua, this: &OpCodeInfo) -> 1 {
 		unsafe { lua.push(this.inner.is_save_restore()); }

--- a/src/rust/iced-x86-py/src/iced_x86/_iced_x86_py.pyi
+++ b/src/rust/iced-x86-py/src/iced_x86/_iced_x86_py.pyi
@@ -3475,7 +3475,7 @@ class Instruction:
 		...
 	@property
 	def is_save_restore_instruction(self) -> bool:
-		"""bool: `True` if it's an instruction that saves or restores too many registers (eg. `FXRSTOR`, `XSAVE`, etc)."""
+		"""bool: `True` if it's an instruction that saves or restores many registers (eg. `FXRSTOR`, `XSAVE`, etc)."""
 		...
 	@property
 	def is_string_instruction(self) -> bool:
@@ -7669,7 +7669,7 @@ class OpCodeInfo:
 		...
 	@property
 	def is_save_restore(self) -> bool:
-		"""bool: `True` if it reads/writes too many registers"""
+		"""bool: `True` if it reads/writes to many registers"""
 		...
 	@property
 	def is_stack_instruction(self) -> bool:

--- a/src/rust/iced-x86-py/src/instruction.rs
+++ b/src/rust/iced-x86-py/src/instruction.rs
@@ -1642,7 +1642,7 @@ impl Instruction {
 		self.instr.is_stack_instruction()
 	}
 
-	/// bool: ``True`` if it's an instruction that saves or restores too many registers (eg. ``FXRSTOR``, ``XSAVE``, etc).
+	/// bool: ``True`` if it's an instruction that saves or restores many registers (eg. ``FXRSTOR``, ``XSAVE``, etc).
 	#[getter]
 	fn is_save_restore_instruction(&self) -> bool {
 		self.instr.is_save_restore_instruction()

--- a/src/rust/iced-x86-py/src/op_code_info.rs
+++ b/src/rust/iced-x86-py/src/op_code_info.rs
@@ -475,7 +475,7 @@ impl OpCodeInfo {
 		self.info.is_privileged()
 	}
 
-	/// bool: ``True`` if it reads/writes too many registers
+	/// bool: ``True`` if it reads/writes to many registers
 	#[getter]
 	fn is_save_restore(&self) -> bool {
 		self.info.is_save_restore()

--- a/src/rust/iced-x86/src/code.rs
+++ b/src/rust/iced-x86/src/code.rs
@@ -44662,7 +44662,7 @@ impl Code {
 		(crate::info::info_table::TABLE[self as usize].1 & InfoFlags2::STACK_INSTRUCTION) != 0
 	}
 
-	/// Checks if it's an instruction that saves or restores too many registers (eg. `FXRSTOR`, `XSAVE`, etc).
+	/// Checks if it's an instruction that saves or restores many registers (eg. `FXRSTOR`, `XSAVE`, etc).
 	#[must_use]
 	#[inline]
 	pub fn is_save_restore_instruction(self) -> bool {

--- a/src/rust/iced-x86/src/encoder/op_code.rs
+++ b/src/rust/iced-x86/src/encoder/op_code.rs
@@ -937,7 +937,7 @@ impl OpCodeInfo {
 		(self.opc_flags1 & OpCodeInfoFlags1::PRIVILEGED) != 0
 	}
 
-	/// `true` if it reads/writes too many registers
+	/// `true` if it reads/writes to many registers
 	#[must_use]
 	#[inline]
 	pub const fn is_save_restore(&self) -> bool {

--- a/src/rust/iced-x86/src/instruction.rs
+++ b/src/rust/iced-x86/src/instruction.rs
@@ -3150,7 +3150,7 @@ impl Instruction {
 		self.code().is_stack_instruction()
 	}
 
-	/// `true` if it's an instruction that saves or restores too many registers (eg. `FXRSTOR`, `XSAVE`, etc).
+	/// `true` if it's an instruction that saves or restores many registers (eg. `FXRSTOR`, `XSAVE`, etc).
 	#[must_use]
 	#[inline]
 	pub fn is_save_restore_instruction(&self) -> bool {


### PR DESCRIPTION
"reads/writes too many registers" -> "reads/writes to many registers"