### PR TITLE
Allow creating decoder over raw slice pointer without aliasing

### DIFF
--- a/src/rust/iced-x86/Cargo.toml
+++ b/src/rust/iced-x86/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["disassembler", "assembler", "x86", "amd64", "x86_64"]
 categories = ["no-std", "development-tools::debugging", "encoding", "hardware-support", "wasm"]
 # Don't include the tests when uploading to crates.io
 exclude = ["/src/**/test/", "/src/**/tests/", "/src/**/test_utils/"]
-rust-version = "1.63.0"
+rust-version = "1.79.0"
 
 # These features are documented in README.md / lib.rs
 [features]

--- a/src/rust/iced-x86/src/decoder.rs
+++ b/src/rust/iced-x86/src/decoder.rs
@@ -585,6 +585,14 @@ where
 	phantom: PhantomData<&'a [u8]>
 }
 
+// Safety: decoder is safe to send between threads
+unsafe impl<'a> Send for Decoder<'a> {}
+
+// Safety: data read by decoder is borrowed from an immutable u8 slice, unless
+// using the unsafe `try_with_slice_ptr` constructor. In this case, the caller
+// is responsible for making sure the slice pointer is never written to
+unsafe impl<'a> Sync for Decoder<'a> {}
+
 macro_rules! write_base_reg {
 	($instruction:ident, $expr:expr) => {
 		debug_assert!($expr < IcedConstants::REGISTER_ENUM_COUNT as u32);


### PR DESCRIPTION
Currently, the `Decoder` keeps a reference to the data slice passed in constructors. This means that there is no way to unsafely create a decoder over a partially valid or aliased memory range (where we assert that the specific subslices at which we'll be decoding are safe to read) without immediately causing UB. Because the decoder uses raw pointers internally in its logic, this seems like an unnecessary restriction which forces re-creating decoders every time we want to decode at an arbitrary address. 

This PR adds an unsafe constructor, `try_with_slice_ptr`, which lets one construct a decoder from a raw slice pointer. To avoid aliasing, the `data` field in the `Decoder` struct is replaced by a slice pointer, and the reference is moved inside a `PhantomData`. 

Since the `slice_ptr_len` feature was only stabilized in 1.79, this does require bumping the MSRV, which I understand is probably not desirable. In this case the constructor could be replaced by `try_with_raw_parts` which takes a `*const u8` and length instead. 