### PR TITLE
Added a return method for the Instruction and Code structures

### DIFF
--- a/src/rust/iced-x86/src/code.rs
+++ b/src/rust/iced-x86/src/code.rs
@@ -44668,6 +44668,19 @@ impl Code {
 		(crate::info::info_table::TABLE[self as usize].1 & InfoFlags2::SAVE_RESTORE) != 0
 	}
 
+	/// Checks if it's a return instruction
+	#[must_use]
+	#[inline]
+	pub const fn is_return(self) -> bool {
+		return match self{
+			Code::Retnw | Code::Retnw_imm16 | Code::Retnd |  Code::Retnd_imm16 | Code::Retnq | Code::Retnq_imm16 |
+			Code::Retfw | Code::Retfw_imm16 | Code::Retfd | Code::Retfd_imm16 | Code::Retfq | Code::Retfq_imm16 |
+			Code::Iretd | Code::Iretq | Code::Iretw | Code::Sysretd | Code::Sysretq | Code::Uiret |
+			Code::Sysexitd | Code::Sysexitq => true,
+			_ => false
+		}
+	}
+
 	/// Checks if it's a `Jcc NEAR` instruction
 	#[must_use]
 	#[inline]

--- a/src/rust/iced-x86/src/instruction.rs
+++ b/src/rust/iced-x86/src/instruction.rs
@@ -3464,6 +3464,13 @@ impl Instruction {
 		crate::info::rflags_table::FLAGS_MODIFIED[self.rflags_info() as usize] as u32
 	}
 
+	/// Checks if it's a return instruction
+	#[must_use]
+	#[inline]
+	pub const fn is_return(&self) -> bool {
+		self.code().is_return()
+	}
+
 	/// Checks if it's a `Jcc SHORT` or `Jcc NEAR` instruction
 	#[must_use]
 	#[inline]

--- a/src/rust/iced-x86/src/test/instr_misc.rs
+++ b/src/rust/iced-x86/src/test/instr_misc.rs
@@ -698,3 +698,21 @@ fn verify_get_set_immediate() {
 fn verify_instruction_size() {
 	const _: () = assert!(mem::size_of::<Instruction>() == INSTRUCTION_TOTAL_SIZE);
 }
+
+#[test]
+fn checks_if_return_instruction(){
+	let machine_code: [u8; 9]  = [0xc2, 0x90, 0x90, 0xc3, 0xca, 090, 0x90, 0xcb, 0xcf];
+	let bad: [u8; 5] = [0xcc, 0x90, 0x00, 0x00, 0xd7//xlatb];
+	let mut formatter: NasmFormatter = NasmFormatter::new();
+	let mut output: String = String::new();
+	let mut decoder: Decoder<'_> = Decoder::with_ip(32, &machine_code, 0x0000_0004_0000_0000, DecoderOptions::NONE);
+
+	for inst in &mut decoder{
+		assert_eq!(true, inst.is_return());		//Function added
+	};
+
+	decoder = Decoder::with_ip(32, &bad, 0x0000_0004_0000_0000, DecoderOptions::NONE);
+	for inst in &mut decoder{
+		assert_eq!(false, inst.is_return());	//Function added
+	};
+}


### PR DESCRIPTION
I added a is_return method for the Instruction and Code structures in the rust bindings to make it easier to check when we stumble on a return instruction while disassembling