### PR TITLE
Rust: Make `Encoder` rollback to previous buffer on error

### DIFF
--- a/src/rust/iced-x86/src/encoder.rs
+++ b/src/rust/iced-x86/src/encoder.rs
@@ -271,6 +271,7 @@ impl Encoder {
 		// requires 3 instructions.
 		self.sib = 0;
 
+		let position = self.buffer.len();
 		let handler = self.handlers[instruction.code() as usize];
 		self.handler = handler;
 		self.op_code = handler.op_code;
@@ -354,6 +355,7 @@ impl Encoder {
 			self.set_error_message(format!("Instruction length > {} bytes", IcedConstants::MAX_INSTRUCTION_LENGTH));
 		}
 		if !self.error_message.is_empty() {
+			self.buffer.truncate(position);
 			Err(IcedError::with_string(mem::take(&mut self.error_message)))
 		} else {
 			Ok(instr_len)


### PR DESCRIPTION
As it stands the `Encoder` api on error leaves junk in `Encoder.buffer` forcing user code to work around it

```rust
let buf = encoder.take_buffer();
let len = buf.len();
encoder.set_buffer(buf);

if let Ok(l) = encoder.encode(instruction, ip) {
    // ...
} else {
    let mut buf = encoder.take_buffer();
    buf.truncate(len);
    encoder.set_buffer(buf);
}
```

this PR makes the buffer truncate happen directly in the `Encoder::encode` call