### PR TITLE
tests: Update enc= values to preserve useless 0x67 address-size prefix

### DIFF
--- a/src/UnitTests/Intel/Decoder/DecoderTest16.txt
+++ b/src/UnitTests/Intel/Decoder/DecoderTest16.txt
@@ -21483,7 +21483,7 @@ C4C37B F0 10 5A, VEX_Rorx_r32_rm32_imm8, Rorx, 3, op0=r;edx op1=m;ds;bx;si;1;0;0
 8FE978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx
 8FE9F8 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=8FE97812C3
 8FC978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=8FE97812C3
-67 8FE978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=8FE97812C3
+67 8FE978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=678FE97812C3
 
 8FE978 12 CB, XOP_Slwpcb_r32, Slwpcb, 1, op0=r;ebx
 8FE9F8 12 CB, XOP_Slwpcb_r32, Slwpcb, 1, op0=r;ebx enc=8FE97812CB

--- a/src/UnitTests/Intel/Decoder/DecoderTest32.txt
+++ b/src/UnitTests/Intel/Decoder/DecoderTest32.txt
@@ -21485,7 +21485,7 @@ C4C37B F0 10 5A, VEX_Rorx_r32_rm32_imm8, Rorx, 3, op0=r;edx op1=m;ds;eax;;1;0;0;
 8FE978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx
 8FE9F8 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=8FE97812C3
 8FC978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=8FE97812C3
-67 8FE978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=8FE97812C3
+67 8FE978 12 C3, XOP_Llwpcb_r32, Llwpcb, 1, op0=r;ebx enc=678FE97812C3
 
 8FE978 12 CB, XOP_Slwpcb_r32, Slwpcb, 1, op0=r;ebx
 8FE9F8 12 CB, XOP_Slwpcb_r32, Slwpcb, 1, op0=r;ebx enc=8FE97812CB

--- a/src/rust/iced-x86/src/decoder/handlers/legacy.rs
+++ b/src/rust/iced-x86/src/decoder/handlers/legacy.rs
@@ -9,6 +9,7 @@ use crate::decoder::handlers::*;
 use crate::decoder::*;
 use crate::iced_constants::IcedConstants;
 use crate::instruction_internal;
+use crate::OpKind;
 
 // SAFETY:
 //	code: let this = unsafe { &*(self_ptr as *const Self) };
@@ -213,6 +214,14 @@ impl OpCodeHandler_Prefix67 {
 
 		decoder.reset_rex_prefix_state();
 		decoder.call_opcode_handlers_map0_table(instruction);
+
+		// If the instruction has no memory operand of any kind, the 0x67 prefix had no
+		// semantic effect. Record it so formatters can emit a16/a32/a64 to reproduce the
+		// original encoding. All memory-related OpKind values start at MemorySegSI (15).
+		let has_mem = (0..instruction.op_count()).any(|i| instruction.op_kind(i) as u32 >= OpKind::MemorySegSI as u32);
+		if !has_mem {
+			instruction.set_has_address_size_prefix(true);
+		}
 	}
 }
 

--- a/src/rust/iced-x86/src/encoder.rs
+++ b/src/rust/iced-x86/src/encoder.rs
@@ -1150,7 +1150,7 @@ impl Encoder {
 		if (self.encoder_flags & EncoderFlags::P66) != 0 {
 			self.write_byte_internal(0x66);
 		}
-		if (self.encoder_flags & EncoderFlags::P67) != 0 {
+		if (self.encoder_flags & EncoderFlags::P67) != 0 || instruction.has_address_size_prefix() {
 			self.write_byte_internal(0x67);
 		}
 		if can_write_f3 && instruction.has_repe_prefix() {

--- a/src/rust/iced-x86/src/encoder/tests/mod.rs
+++ b/src/rust/iced-x86/src/encoder/tests/mod.rs
@@ -2266,3 +2266,4 @@ fn test_invalid_br(
 		assert!(encoder.encode(&instr, instr_addr).is_err());
 	}
 }
+

--- a/src/rust/iced-x86/src/formatter/nasm.rs
+++ b/src/rust/iced-x86/src/formatter/nasm.rs
@@ -146,11 +146,12 @@ impl NasmFormatter {
 		let mut need_space = false;
 		if (mnemonic_options & FormatMnemonicOptions::NO_PREFIXES) == 0 && (op_info.flags & InstrOpInfoFlags::MNEMONIC_IS_DIRECTIVE) == 0 {
 			let prefix_seg = instruction.segment_prefix();
+			let has_useless_addr_pfx = instruction.has_address_size_prefix() && self.d.options.show_useless_prefixes();
 
 			const PREFIX_FLAGS: u32 = (InstrOpInfoFlags::SIZE_OVERRIDE_MASK << InstrOpInfoFlags::OP_SIZE_SHIFT)
 				| (InstrOpInfoFlags::SIZE_OVERRIDE_MASK << InstrOpInfoFlags::ADDR_SIZE_SHIFT)
 				| InstrOpInfoFlags::BND_PREFIX;
-			if ((prefix_seg as u32) | instruction_internal::internal_has_any_of_lock_rep_repne_prefix(instruction) | (op_info.flags & PREFIX_FLAGS))
+			if ((prefix_seg as u32) | instruction_internal::internal_has_any_of_lock_rep_repne_prefix(instruction) | (op_info.flags & PREFIX_FLAGS) | has_useless_addr_pfx as u32)
 				!= 0
 			{
 				let mut prefix;
@@ -165,6 +166,16 @@ impl NasmFormatter {
 					[((op_info.flags as usize) >> InstrOpInfoFlags::ADDR_SIZE_SHIFT) & InstrOpInfoFlags::SIZE_OVERRIDE_MASK as usize];
 				if !prefix.is_default() {
 					NasmFormatter::format_prefix(&self.d.options, output, instruction, column, prefix, PrefixKind::AddressSize, &mut need_space);
+				}
+
+				if has_useless_addr_pfx {
+					// Emit a16/a32 to reproduce the useless 0x67 prefix.
+					// 0x67 in 32-bit mode selects 16-bit addressing; in 16/64-bit mode it selects 32-bit.
+					let addr_pfx = match instruction.code_size() {
+						CodeSize::Code32 => &self.d.str_.a16,
+						_ => &self.d.str_.a32,
+					};
+					NasmFormatter::format_prefix(&self.d.options, output, instruction, column, addr_pfx, PrefixKind::AddressSize, &mut need_space);
 				}
 
 				let has_notrack_prefix = prefix_seg == Register::DS && is_notrack_prefix_branch(instruction.code());

--- a/src/rust/iced-x86/src/instruction.rs
+++ b/src/rust/iced-x86/src/instruction.rs
@@ -28,6 +28,7 @@ impl InstrFlags1 {
 	pub(crate) const OP_MASK_SHIFT: u32 = 0x0000_000F;
 	pub(crate) const CODE_SIZE_MASK: u32 = 0x0000_0003;
 	pub(crate) const CODE_SIZE_SHIFT: u32 = 0x0000_0012;
+	pub(crate) const HAS_ADDRESS_SIZE_PREFIX: u32 = 0x0010_0000;
 	pub(crate) const BROADCAST: u32 = 0x0400_0000;
 	pub(crate) const SUPPRESS_ALL_EXCEPTIONS: u32 = 0x0800_0000;
 	pub(crate) const ZEROING_MASKING: u32 = 0x1000_0000;
@@ -484,6 +485,30 @@ impl Instruction {
 			self.flags1 |= InstrFlags1::LOCK_PREFIX;
 		} else {
 			self.flags1 &= !InstrFlags1::LOCK_PREFIX;
+		}
+	}
+
+	/// `true` if the instruction has a useless address-size prefix (`67h`) that the decoder
+	/// could not associate with any memory operand (e.g. `67 90` = `a32 nop` in 32-bit mode).
+	/// Formatters should emit an `a16`/`a32`/`a64` keyword when this is `true` so that
+	/// assemblers can reproduce the original encoding.
+	#[must_use]
+	#[inline]
+	pub const fn has_address_size_prefix(&self) -> bool {
+		(self.flags1 & InstrFlags1::HAS_ADDRESS_SIZE_PREFIX) != 0
+	}
+
+	/// `true` if the instruction has a useless address-size prefix (`67h`)
+	///
+	/// # Arguments
+	///
+	/// * `new_value`: new value
+	#[inline]
+	pub fn set_has_address_size_prefix(&mut self, new_value: bool) {
+		if new_value {
+			self.flags1 |= InstrFlags1::HAS_ADDRESS_SIZE_PREFIX;
+		} else {
+			self.flags1 &= !InstrFlags1::HAS_ADDRESS_SIZE_PREFIX;
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Update 25 `enc=` entries in `DecoderTest{16,32,64}.txt` to include the leading `67` byte
- These entries have a `0x67` prefix in the original bytes; with `has_address_size_prefix` now preserved through encode, the re-encoded bytes include `67` and the test expectations must match

Depends on: #802, #803

## Test plan

- [x] `cargo test -p iced-x86 -- encode_16 encode_32 encode_64` passes